### PR TITLE
Initial verification setup

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,44 @@
+---
+name: Verification tests
+
+on: [push, pull_request]
+
+
+jobs:
+  build:
+    name: Verify
+    runs-on: ubuntu-latest  # container actions require GNU/Linux
+    strategy:
+      matrix:
+        coq_container:
+        - coqorg/coq:8.17.1-ocaml-4.14.1-flambda
+    container:
+      image: ${{ matrix.coq_container }}
+      options: --user root
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Fix permissions
+      run: chown -R 1000 .
+    - name: ls
+      run: ls -la .
+    - name: Install openssl dependency
+      run: 'sudo apt update && sudo apt install libssl-dev -y'
+    - name: Pull RefinedRust
+      run: su coq -c 'git clone https://gitlab.mpi-sws.org/lgaeher/refinedrust-dev.git verification/refinedrust'
+    - name: Install rustup
+      run: su coq -c 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | bash /dev/stdin "-y"'
+    - name: Setup Rust toolchain
+      run: su coq -c 'source "$HOME/.cargo/env" && REFINEDRUST_ROOT=$PWD/verification/refinedrust ./verification/refinedrust/scripts/setup-rust.sh'
+    - name: Install frontend
+      run: su coq -c 'source "$HOME/.cargo/env" && REFINEDRUST_ROOT=$PWD/verification/refinedrust ./verification/refinedrust/scripts/install-frontend.sh'
+    - name: Install Opam dependencies
+      run: su coq -c 'eval $(opam env) && REFINEDRUST_ROOT=$PWD/verification/refinedrust ./verification/refinedrust/scripts/setup-coq.sh'
+    - name: Install RefinedRust type system
+      run: su coq -c 'eval $(opam env) && REFINEDRUST_ROOT=$PWD/verification/refinedrust ./verification/refinedrust/scripts/install-typesystem.sh'
+    - name: Translate specified files using RefinedRust
+      run: su coq -c 'source "$HOME/.cargo/env" && eval $(opam env) && REFINEDRUST="refinedrust_translate" make verify'
+    - name: Check proofs
+      run: su coq -c 'eval $(opam env) && cd verification && dune build'

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ tools: setup
 	mkdir -p $(TOOLS_WORK_DIR)
 	cp -rf $(TOOLS_SOURCE_DIR)/* $(TOOLS_WORK_DIR)
 
+verify:
+	ACE_DIR=$(ACE_DIR) $(MAKE) -C verification
+
 clean:
 	rm -rf $(ACE_DIR)
 

--- a/verification/.gitignore
+++ b/verification/.gitignore
@@ -1,0 +1,6 @@
+_opam
+_build
+log 
+rustc-ice-*
+refinedrust
+generated_code

--- a/verification/Makefile
+++ b/verification/Makefile
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2023 IBM Corporation
+# SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
+# SPDX-License-Identifier: Apache-2.0
+MAKEFILE_PATH 							:= $(abspath $(lastword $(MAKEFILE_LIST)))
+MAKEFILE_SOURCE_DIR 					:= $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
+REFINEDRUST ?= refinedrust_translate
+
+# TODO: currently, this builds in-tree.
+# It would be good if we could build in the ACE_DIR
+# Main Problem: generating the RefinedRust files there.
+
+## Verification-related make targets
+# a list of Rust source files to verify
+VERIFICATION_TARGETS =
+# ../security-monitor/src/core/memory_tracker/test.rs
+
+# generate the Coq code for a particular Rust file
+# TODO: configure output directory for Refinedrust
+%.rs.gen: %.rs
+	@$(REFINEDRUST) $<
+.PHONY: phony
+
+# generate Coq code for all verification targets
+generate_all: $(addsuffix .gen, $(VERIFICATION_TARGETS))
+.PHONY: generate_all
+
+echo_toolchain:
+	@echo "Using RefinedRust toolchain located at $(REFINEDRUST)"
+
+verify: echo_toolchain generate_all
+	@dune build --display short
+
+clean:
+	rm -rf $(ACE_DIR)
+	# TODO: clean generated proof files

--- a/verification/RefinedRust.toml
+++ b/verification/RefinedRust.toml
@@ -1,0 +1,5 @@
+dump_borrowck_info=false
+output_dir="./generated_code"
+log_dir = "./log"
+shims = "rr_shims.json"
+run_check = false

--- a/verification/_CoqProject
+++ b/verification/_CoqProject
@@ -1,0 +1,11 @@
+# We sometimes want to locally override notation, and there is no good way to do that with scopes.
+-arg -w -arg -notation-overridden
+# Cannot use non-canonical projections as it causes massive unification failures
+# (https://github.com/coq/coq/issues/6294).
+-arg -w -arg -redundant-canonical-projection
+
+## example theory for manually proved things
+# -Q _build/default/theories/theory ace.theory
+
+# include RefinedRust-generated theories here
+-Q _build/default/rr_output/security_monitor ace.security_monitor.rr

--- a/verification/dune
+++ b/verification/dune
@@ -1,0 +1,2 @@
+; Add project-wide flags here.
+(dirs :standard \ refinedrust)

--- a/verification/dune-project
+++ b/verification/dune-project
@@ -1,0 +1,4 @@
+(lang dune 3.8)
+(name ace)
+(package (name ace))
+(using coq 0.8)

--- a/verification/rr_shims.json
+++ b/verification/rr_shims.json
@@ -1,0 +1,44 @@
+[
+  {
+    "path": ["std", "mem", "swap"],
+    "kind": "function",
+    "name": "std_mem_swap",
+    "spec": "type_of_mem_swap"
+  }, 
+  {
+    "path": ["std", "boxed", "Box", "new"],
+    "kind": "method",
+    "name": "box_new",
+    "spec": "type_of_box_new"
+  },
+  {
+    "path": ["std", "mem", "size_of"],
+    "kind": "function",
+    "name": "std_mem_size_of",
+    "spec": "type_of_mem_size_of"
+  },
+  { 
+    "path": ["std", "ptr", "read"],
+    "kind": "function",
+    "name": "std_ptr_read",
+    "spec": "type_of_ptr_read"
+  },
+  { 
+    "path": ["std", "ptr", "write"],
+    "kind": "function",
+    "name": "std_ptr_write",
+    "spec": "type_of_ptr_write"
+  },
+  { 
+    "path": ["std", "ptr", "copy"],
+    "kind": "function",
+    "name": "std_ptr_copy",
+    "spec": "type_of_ptr_copy"
+  },
+  { 
+    "path": ["std", "option", "Option", "unwrap"],
+    "kind": "method",
+    "name": "std_option_Option_unwrap_def",
+    "spec": "type_of_std_option_Option_unwrap"
+  }
+]

--- a/verification/setup.md
+++ b/verification/setup.md
@@ -1,0 +1,60 @@
+# ACE Verification Setup
+
+We aim to verify parts of the ACE Security Monitor using the [RefinedRust toolchain](https://gitlab.mpi-sws.org/lgaeher/refinedrust-dev) and the [Coq proof assistant](https://coq.inria.fr/).
+This file documents the basic verification setup.
+
+
+## Architecture
+
+
+## Installation
+For using the RefinedRust toolchain and checking the verified parts of the code, you need to install both the Coq proof assistant and RefinedRust Coq libraries as well as the RefinedRust frontend.
+
+First of all, open a terminal and navigate to the directory containing this file.
+Then, clone the RefinedRust repository into a subdirectory:
+```
+git clone https://gitlab.mpi-sws.org/lgaeher/refinedrust-dev.git refinedrust
+```
+
+### Installing Coq and the RefinedRust Coq libraries
+
+First of all, we will install Coq and the RefinedRust Coq implementation.
+For that, you are going to need [opam](https://opam.ocaml.org/) installed.
+If you have not installed opam yet, refer to the instructions at https://opam.ocaml.org/doc/Install.html.
+After the first installation, run `opam init`.
+
+Now, run the following commands in the shell opened previously:
+```
+opam switch create refinedrust-ace --packages=ocaml-variants.4.14.1+options,ocaml-option-flambda
+eval $(opam env)
+opam switch link refinedrust-ace .
+
+REFINEDRUST_ROOT=$PWD/refinedrust ./refinedrust/scripts/setup-coq.sh
+REFINEDRUST_ROOT=$PWD/refinedrust ./refinedrust/scripts/install-typesystem.sh
+
+```
+
+The setup script will setup your opam switch to include all dependencies of RefinedRust.
+Afterwards, we install Lithium (the proof automation engine RefinedRust uses) as well as RefinedRust itself.
+
+### Installing the RefinedRust frontend
+
+In the next step, we setup the RefinedRust frontend used for translating Rust code into Coq.
+For that, you are going to need a working installation of Rust and [rustup](https://rustup.rs/).
+If you do not have rustup installed yet, follow the instructions at https://rustup.rs/.
+
+Now, run the following commands in the shell opened previously:
+```
+REFINEDRUST_ROOT=$PWD/refinedrust ./refinedrust/scripts/setup-rust.sh
+REFINEDRUST_ROOT=$PWD/refinedrust ./refinedrust/scripts/install-frontend.sh
+```
+
+This will install a binary `refinedrust_translate` in the rustup toolchain for RefinedRust, which is available afterwards.
+
+## Verifying the code
+
+Now, we are ready to run the verification.
+To that end, run
+```
+REFINEDRUST=refinedrust_translate make verify
+```

--- a/verification/theories/page/dune
+++ b/verification/theories/page/dune
@@ -1,0 +1,6 @@
+(coq.theory
+ (name ace.theories.page)
+ (package ace)
+ (flags -w -notation-overridden -w -redundant-canonical-projection)
+ (synopsis "Manual proofs for ACE Security Monitor page")
+ (theories stdpp iris Ltac2 caesium lithium lrust RecordUpdate Equations refinedrust))

--- a/verification/theories/page/page_extra.v
+++ b/verification/theories/page/page_extra.v
@@ -1,0 +1,1 @@
+From refinedrust Require Import typing.


### PR DESCRIPTION
This PR does the first step of integrating verification into ACE. 
* Add a `verification` folder containing a skeleton for adding Coq files built with the `dune` build system, as well as basic RefinedRust configuration. The Rust source files to verify are listed in `verification/Makefile` (currently none).
* Add a `make verify` target that runs the verification harness.
* `verification/setup.md` contains a description of the verification toolchain as well as instructions for setting it up locally.
* Add a `verify` GitHub action that runs `make verify`.

Currently, the `verify` target creates files for verification in-tree, i.e. not in `$ACE_DIR`. 