### PR TITLE
Adding explicit support for a subset of SBI extensions (hypercalls).

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,6 @@
 		"**/.git/**": true
 	},
 	"editor.codeActionsOnSave": {
-        "source.organizeImports": true
-    }
+		"source.organizeImports": "explicit"
+	}
 }

--- a/security-monitor/src/confidential_flow/context_switch/enter_from_confidential_vm.S
+++ b/security-monitor/src/confidential_flow/context_switch/enter_from_confidential_vm.S
@@ -142,4 +142,6 @@ enter_from_confidential_vm_asm:
     # mscratch must point to the per HART data structure
     # sscratch must point to the confidential VM's vHART data structure
     # first argument (a0) must point to the dumped hart memory area
+    # TODO: Prove that we don't violate C calling conventions and parameters 
+    # are correctly passed.
     j        enter_from_confidential_vm

--- a/security-monitor/src/confidential_flow/control_flow/mod.rs
+++ b/security-monitor/src/confidential_flow/control_flow/mod.rs
@@ -2,7 +2,8 @@
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
 use crate::core::control_data::{ConfidentialVmId, ControlData, HardwareHart};
-use crate::core::transformations::{ExposeToConfidentialVm, PendingRequest, TrapReason};
+use crate::core::transformations::SbiExtension::*;
+use crate::core::transformations::{AceExtension, BaseExtension, ExposeToConfidentialVm, PendingRequest};
 use crate::non_confidential_flow::NonConfidentialFlow;
 
 extern "C" {
@@ -19,50 +20,42 @@ impl<'a> ConfidentialFlow<'a> {
     }
 
     pub fn route(self) -> ! {
-        use crate::confidential_flow::handlers::{
-            guest_load_page_fault, guest_store_page_fault, hypercall, interrupt, invalid_call, share_page,
-        };
-        use crate::ACE_EXT_ID;
-        const SHARE_PAGE_FID: usize = 2000;
+        use crate::confidential_flow::handlers::*;
+        use crate::core::transformations::TrapReason::*;
 
         let confidential_hart = self.hart.confidential_hart();
-
         match confidential_hart.trap_reason() {
-            TrapReason::Interrupt => interrupt::handle(self),
-            TrapReason::VsEcall(ACE_EXT_ID, SHARE_PAGE_FID) => {
+            Interrupt => interrupt::handle(self),
+            VsEcall(Ace(AceExtension::SharePageWithHypervisor)) => {
                 share_page::handle(confidential_hart.share_page_request(), self)
             }
-            TrapReason::VsEcall(ACE_EXT_ID, function_id) => invalid_call::handle(self, ACE_EXT_ID, function_id),
-            TrapReason::VsEcall(_, _) => hypercall::handle(confidential_hart.hypercall_request(), self),
-            TrapReason::GuestLoadPageFault => {
+            VsEcall(Ace(_)) => invalid_call::handle(self),
+            VsEcall(Base(BaseExtension::Unknown(_, _))) => invalid_call::handle(self),
+            VsEcall(Base(_)) => hypercall::handle(confidential_hart.hypercall_request(), self),
+            VsEcall(_) => hypercall::handle(confidential_hart.hypercall_request(), self),
+            GuestLoadPageFault => {
                 guest_load_page_fault::handle(confidential_hart.guest_load_page_fault_request(), self)
             }
-            TrapReason::GuestStorePageFault => {
+            GuestStorePageFault => {
                 guest_store_page_fault::handle(confidential_hart.guest_store_page_fault_request(), self)
             }
-            TrapReason::Unknown(extension_id, function_id) => invalid_call::handle(self, extension_id, function_id),
-            TrapReason::HsEcall(_, _) => {
-                panic!("Bug: Incorrect interrupt delegation configuration")
-            }
-            TrapReason::StoreAccessFault => {
-                panic!("Bug: Incorrect interrupt delegation configuration")
-            }
+            HsEcall(_) => panic!("Bug: Incorrect interrupt delegation configuration"),
+            StoreAccessFault => panic!("Bug: Incorrect interrupt delegation configuration"),
+            _ => invalid_call::handle(self),
         }
     }
 
     pub fn finish_request(self) -> ! {
-        use crate::confidential_flow::handlers::{
-            guest_load_page_fault_result, guest_store_page_fault_result, hypercall_result, share_page_result,
-        };
+        use crate::confidential_flow::handlers::*;
+        use crate::core::transformations::PendingRequest::*;
+
         match self.hart.confidential_hart_mut().take_request() {
-            Some(PendingRequest::SbiRequest()) => hypercall_result::handle(self.hart.hypercall_result(), self),
-            Some(PendingRequest::GuestLoadPageFault(request)) => {
+            Some(SbiRequest()) => hypercall_result::handle(self.hart.hypercall_result(), self),
+            Some(GuestLoadPageFault(request)) => {
                 guest_load_page_fault_result::handle(self.hart.guest_load_page_fault_result(request), self)
             }
-            Some(PendingRequest::GuestStorePageFault(request)) => guest_store_page_fault_result::handle(self, request),
-            Some(PendingRequest::SharePage(request)) => {
-                share_page_result::handle(self.hart.share_page_result(), self, request)
-            }
+            Some(GuestStorePageFault(request)) => guest_store_page_fault_result::handle(self, request),
+            Some(SharePage(request)) => share_page_result::handle(self.hart.share_page_result(), self, request),
             None => self.exit_to_confidential_vm(ExposeToConfidentialVm::Resume()),
         }
     }

--- a/security-monitor/src/confidential_flow/control_flow/mod.rs
+++ b/security-monitor/src/confidential_flow/control_flow/mod.rs
@@ -10,11 +10,14 @@ extern "C" {
     fn exit_to_confidential_vm_asm(confidential_hart_address: usize) -> !;
 }
 
+/// The token that ensures correct control flow integrity within the `confidential flow` part of the finite state
+/// machine (FSM) of the security monitor.
 pub struct ConfidentialFlow<'a> {
     hart: &'a mut HardwareHart,
 }
 
 impl<'a> ConfidentialFlow<'a> {
+    /// Creates the confidential flow token.
     pub fn create(hart: &'a mut HardwareHart) -> Self {
         Self { hart }
     }

--- a/security-monitor/src/confidential_flow/handlers/invalid_call.rs
+++ b/security-monitor/src/confidential_flow/handlers/invalid_call.rs
@@ -4,10 +4,8 @@
 use crate::confidential_flow::ConfidentialFlow;
 use crate::error::Error;
 
-pub fn handle(confidential_flow: ConfidentialFlow, extension_id: usize, function_id: usize) -> ! {
+pub fn handle(confidential_flow: ConfidentialFlow) -> ! {
     let mcause = riscv::register::mcause::read().code();
-
-    let transformation = Error::InvalidCall(mcause, extension_id, function_id).into_confidential_transformation();
-
+    let transformation = Error::InvalidCall(mcause).into_confidential_transformation();
     confidential_flow.exit_to_confidential_vm(transformation)
 }

--- a/security-monitor/src/core/memory_layout/confidential_memory_address.rs
+++ b/security-monitor/src/core/memory_layout/confidential_memory_address.rs
@@ -4,6 +4,7 @@
 use crate::error::Error;
 use pointers_utility::{ptr_byte_add_mut, ptr_byte_offset};
 
+/// The wrapper over a raw pointer that is guaranteed to be an address located in the confidential memory region.
 #[repr(transparent)]
 #[derive(Debug, PartialEq)]
 pub struct ConfidentialMemoryAddress(*mut usize);
@@ -13,10 +14,9 @@ impl ConfidentialMemoryAddress {
         Self(address)
     }
 
-    // TODO: check if needed. If yes, make sure the raw pointer is not used incorrectly
-    // Currently we only use it during creation of the heap allocator structure. It
-    // would be good to get rid of this because it requires extra safety guarantees for
-    // parallel execution of the security monitor
+    // TODO: check if needed. If yes, make sure the raw pointer is not used incorrectly Currently we only use it during
+    // creation of the heap allocator structure. It would be good to get rid of this because it requires extra safety
+    // guarantees for parallel execution of the security monitor
     pub unsafe fn into_mut_ptr(self) -> *mut usize {
         self.0
     }
@@ -33,13 +33,12 @@ impl ConfidentialMemoryAddress {
         ptr_byte_offset(pointer, self.0)
     }
 
-    /// Creates a new confidential memory address at given offset. Error is returned if the resulting
-    /// address exceeds the upper boundary.
+    /// Creates a new confidential memory address at given offset. Error is returned if the resulting address exceeds
+    /// the upper boundary.
     ///
     /// # Safety
     ///
-    /// The caller takes the responsibility to ensure that the address at given offset is still in the
-    /// confidential memory.
+    /// The caller must ensure that the address at given offset is still within the confidential memory region.
     pub unsafe fn add(
         &self, offset_in_bytes: usize, upper_bound: *const usize,
     ) -> Result<ConfidentialMemoryAddress, Error> {
@@ -48,22 +47,22 @@ impl ConfidentialMemoryAddress {
         Ok(ConfidentialMemoryAddress(pointer))
     }
 
-    /// Reads the content of the confidential memory
+    /// Reads usize-sized sequence of bytes from the confidential memory region.
     ///
     /// # Safety
     ///
-    /// We need to ensure the pointer is not used by two threads simultaneously.    
-    /// See `ptr::read_volatile` for safety concerns
+    /// Caller must ensure that the pointer is not used by two threads simultaneously. See `ptr::read_volatile` for
+    /// safety concerns
     pub unsafe fn read_volatile(&self) -> usize {
         self.0.read_volatile()
     }
 
-    /// Writes value to the confidential memory
+    /// Writes usize-sized sequence of bytes to the confidential memory region.
     ///
     /// # Safety
     ///
-    /// We need to ensure the pointer is not used by two threads simultaneously.
-    /// See `ptr::write_volatile` for safety concerns
+    /// Caller must ensure that the pointer is not used by two threads simultaneously. See `ptr::write_volatile` for
+    /// safety concerns
     pub unsafe fn write_volatile(&self, value: usize) {
         self.0.write_volatile(value);
     }

--- a/security-monitor/src/core/memory_layout/mod.rs
+++ b/security-monitor/src/core/memory_layout/mod.rs
@@ -14,13 +14,13 @@ mod non_confidential_memory_address;
 
 const NOT_INITIALIZED_MEMORY_LAYOUT: &str = "Bug. Could not access MemoryLayout because is has not been initialized";
 
-/// MEMORY_LAYOUT is a global static and private to this module variable that is set during the system boot
-/// and never changes later -- this is guaranteed by Once<>. It stores an instance of the `MemoryLayout`.
-/// The only way to get a shared access to this instance is by calling `MemoryLayout::read()` function.
+/// MEMORY_LAYOUT is a static variable (private to this module) that is set during the system boot and never changes
+/// later -- this is guaranteed by Once<>. It stores an instance of the `MemoryLayout`. The only way to get a shared
+/// access to this instance is by calling `MemoryLayout::read()` function.
 static MEMORY_LAYOUT: Once<MemoryLayout> = Once::new();
 
-/// Provides an interface to offset addresses while ensuring that the returned address remains inside
-/// the same memory region, i.e., confidential or non-confidential memory.
+/// Provides an interface to offset addresses that are guaranteed to remain inside the same memory region, i.e.,
+/// confidential or non-confidential memory.
 pub struct MemoryLayout {
     non_confidential_memory_start: *mut usize,
     non_confidential_memory_end: *const usize,
@@ -28,24 +28,23 @@ pub struct MemoryLayout {
     confidential_memory_end: *const usize,
 }
 
-/// We need to declare Send+Sync on the `MemoryLayout` because MemoryLayout stores internally
-/// raw pointers that are not safe to pass in a multi-threaded program. This is not a case
-/// for MemoryLayout because we never expose raw pointers outside the MemoryLayout except for the
-/// constructor when we return the initial address of the confidential memory. The constructor
-/// is invoked only once by the initialization procedure during the boot of the system.
+/// Send+Sync are not automatically declared on the `MemoryLayout` type because it stores internally raw pointers that
+/// are not safe to pass in a multi-threaded program. Declaring Send+Sync is safe because because we never expose raw
+/// pointers outside the MemoryLayout except for the constructor that returns the initial address of the confidential
+/// memory. The constructor is invoked only once by the initialization procedure during the boot of the system when the
+/// system executes only on a one physical hart.
 unsafe impl Send for MemoryLayout {}
 unsafe impl Sync for MemoryLayout {}
 
 impl MemoryLayout {
-    /// Constructs the `MemoryLayout` where the confidential memory is within the memory range defined
-    /// by `confidential_memory_start` and `confidential_memory_end`. Returns the `MemoryLayout` and
-    /// the first alligned address in the confidential memory.
+    /// Constructs the `MemoryLayout` where the confidential memory is within the memory range defined by
+    /// `confidential_memory_start` and `confidential_memory_end`. Returns the `MemoryLayout` and the first alligned
+    /// address in the confidential memory.
     ///
     /// # Safety
     ///
-    /// This function must be called only once by the initialization procedure during the
-    /// boot of the system.
-    pub fn init(
+    /// This function must be called only once by the initialization procedure during the boot of the system.
+    pub unsafe fn init(
         non_confidential_memory_start: *mut usize, non_confidential_memory_end: *const usize,
         confidential_memory_start: *mut usize, mut confidential_memory_end: *const usize,
     ) -> Result<(ConfidentialMemoryAddress, *const usize), Error> {
@@ -53,19 +52,20 @@ impl MemoryLayout {
         assert!(non_confidential_memory_end <= (confidential_memory_start as *const usize));
         assert!((confidential_memory_start as *const usize) < confidential_memory_end);
 
-        // We align the start of the confidential memory to the smalles possible page size (4KiB on RISC-V)
-        // and make sure that its size is the multiply of this page size.
+        // We align the start of the confidential memory to the smallest possible page size (4KiB on RISC-V) and make
+        // sure that its size is the multiply of this page size.
         let smalles_page_size_in_bytes = PageSize::smallest().in_bytes();
         let confidential_memory_start =
             ptr_align(confidential_memory_start, smalles_page_size_in_bytes, confidential_memory_end)
                 .map_err(|_| Error::Init(InitType::NotEnoughMemory))?;
-        // Let's make sure that the end of the confidential memory is properly aligned.
+        // Let's make sure that the end of the confidential memory is properly aligned. I.e., there are no dangling
+        // bytes after the last page.
         let memory_size = ptr_byte_offset(confidential_memory_end, confidential_memory_start);
         let memory_size = usize::try_from(memory_size).map_err(|_| Error::Init(InitType::NotEnoughMemory))?;
         let number_of_pages = memory_size / smalles_page_size_in_bytes;
         let memory_size_in_bytes = number_of_pages * smalles_page_size_in_bytes;
         if memory_size > memory_size_in_bytes {
-            // we must modify the end_address because the current one is not a multiply of the smallest page size
+            // We must modify the end_address because the current one is not a multiply of the smallest page size
             confidential_memory_end =
                 ptr_byte_add_mut(confidential_memory_start, memory_size_in_bytes, confidential_memory_end)?;
         }
@@ -77,14 +77,11 @@ impl MemoryLayout {
             confidential_memory_end,
         });
 
-        // Reconfigure hardware to isolate the confidential memory region
-        let confidential_memory_start = ConfidentialMemoryAddress::new(confidential_memory_start);
-
-        Ok((confidential_memory_start, confidential_memory_end))
+        Ok((ConfidentialMemoryAddress::new(confidential_memory_start), confidential_memory_end))
     }
 
-    /// Returns a an address in the confidential memory offset by given number of bytes from the
-    /// initial address. Returns an error if the resulting address is outside the confidential memory.
+    /// Offsets an address in the confidential memory by a given number of bytes. Returns an error if the resulting
+    /// address is not in the confidential memory region.
     pub fn confidential_address_at_offset(
         &self, address: &ConfidentialMemoryAddress, offset_in_bytes: usize,
     ) -> Result<ConfidentialMemoryAddress, Error> {
@@ -93,9 +90,8 @@ impl MemoryLayout {
         Ok(incremented_address)
     }
 
-    /// Returns a an address in the confidential memory offset by given number of bytes from the
-    /// initial address and not exceeding given upper bound. Returns an error if the resulting address
-    /// is outside the confidential memory or give upped bound.
+    /// Offsets an address in the confidential memory by a given number of bytes. Returns an error if the resulting
+    /// address is outside the confidential memory region or exceeds the given upper bound.
     pub fn confidential_address_at_offset_bounded(
         &self, address: &ConfidentialMemoryAddress, offset_in_bytes: usize, upper_bound: *const usize,
     ) -> Result<ConfidentialMemoryAddress, Error> {
@@ -103,8 +99,8 @@ impl MemoryLayout {
         Ok(self.confidential_address_at_offset(address, offset_in_bytes)?)
     }
 
-    /// Returns a an address in the non-confidential memory offset by given number of bytes from the
-    /// initial address. Returns an error if the resulting address is outside the non-confidential memory.
+    /// Offsets an address in the non-confidential memory by given number of bytes. Returns an error if the resulting
+    /// address is outside the non-confidential memory region.
     pub fn non_confidential_address_at_offset(
         &self, address: &NonConfidentialMemoryAddress, offset_in_bytes: usize,
     ) -> Result<NonConfidentialMemoryAddress, Error> {
@@ -113,7 +109,7 @@ impl MemoryLayout {
         Ok(incremented_address)
     }
 
-    /// Checks if the raw pointer is inside the non-confidential memory.
+    /// Returns true if the raw pointer is inside the non-confidential memory.
     pub fn is_in_non_confidential_range(&self, address: *const usize) -> bool {
         self.non_confidential_memory_start as *const usize <= address && address < self.non_confidential_memory_end
     }
@@ -122,10 +118,10 @@ impl MemoryLayout {
     ///
     /// # Safety
     ///
-    /// Caller must guarantee that there is no other thread that can write to confidential memory during execution
-    /// of this function.
+    /// Caller must guarantee that there is no other thread that can write to confidential memory during execution of
+    /// this function.
     pub unsafe fn clear_confidential_memory(&self) {
-        // We can safely cast below offset to usize because the constructor guarantees that the confidential memory
+        // We can safely cast the below offset to usize because the constructor guarantees that the confidential memory
         // range is valid, and so the memory size must be a valid usize
         let memory_size = ptr_byte_offset(self.confidential_memory_end, self.confidential_memory_start) as usize;
         let usize_alligned_offsets = (0..memory_size).step_by(core::mem::size_of::<usize>());

--- a/security-monitor/src/core/memory_layout/non_confidential_memory_address.rs
+++ b/security-monitor/src/core/memory_layout/non_confidential_memory_address.rs
@@ -5,35 +5,28 @@ use crate::core::memory_layout::MemoryLayout;
 use crate::error::Error;
 use pointers_utility::ptr_byte_add_mut;
 
-/// `NonConfidentialMemoryAddress` represent an address in the non-confidential memory.
-/// The constructor ensures that the address from which this type is instantiated is
-/// inside the non-confidential memory.
+/// The wrapper over a raw pointer that is guaranteed to be an address located in the non-confidential memory region.
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct NonConfidentialMemoryAddress(*mut usize);
 
 impl NonConfidentialMemoryAddress {
-    /// Constructs an address in a non-confidential memory. Returns error if the address
-    /// is outside non-confidential memory.
+    /// Constructs an address in a non-confidential memory. Returns error if the address is outside non-confidential
+    /// memory.
     pub fn new(address: *mut usize) -> Result<Self, Error> {
-        // Safety: We check that the address is within the non-confidential memory range.
-        // This is equavalent to ensure that it does not point to confidential memory as long
-        // as memory is correctly splitted during the initialization procedure. We rely here on
-        // the guarantees from the `MemoryLayout` that cannot be constructed if confidential and
-        // non-confidential memory regions overlap.
         match MemoryLayout::read().is_in_non_confidential_range(address) {
             false => Err(Error::MemoryAccessAuthorization()),
             true => Ok(Self(address)),
         }
     }
 
-    /// Creates a new non-confidential memory address at given offset. Error is returned if the resulting
-    /// address exceeds the upper boundary.
+    /// Creates a new non-confidential memory address at given offset. Returns error if the resulting address exceeds
+    /// the upper boundary.
     ///
     /// # Safety
     ///
-    /// The caller takes the responsibility to ensure that the address advanced by the offset is still in the
-    /// non-confidential memory.
+    /// The caller must ensure that the address advanced by the offset is still within the non-confidential memory
+    /// region.
     pub unsafe fn add(
         &self, offset_in_bytes: usize, upper_bound: *const usize,
     ) -> Result<NonConfidentialMemoryAddress, Error> {
@@ -42,12 +35,12 @@ impl NonConfidentialMemoryAddress {
         Ok(NonConfidentialMemoryAddress(pointer))
     }
 
-    /// Reads the content of the non-confidential memory.
+    /// Reads usize-sized sequence of bytes from the non-confidential memory region.
     ///
     /// # Safety
     ///
-    /// We need to ensure the pointer is not used by two threads simultaneously.
-    /// See `ptr::read_volatile` for safety concerns.
+    /// We need to ensure the pointer is not used by two threads simultaneously. See `ptr::read_volatile` for safety
+    /// concerns.
     pub unsafe fn read(&self) -> usize {
         self.0.read_volatile()
     }

--- a/security-monitor/src/core/memory_protector/hypervisor_memory_protector.rs
+++ b/security-monitor/src/core/memory_protector/hypervisor_memory_protector.rs
@@ -5,8 +5,8 @@ use crate::core::memory_layout::MemoryLayout;
 use crate::core::memory_protector::{iopmp, mmu, pmp};
 use crate::error::Error;
 
-/// Exposes an interface to configure the hardware memory isolation component to
-/// set memory access protection preventing the hypervisor from accessing memory it does not own
+/// Exposes an interface to configure the hardware memory isolation component to set memory access protection preventing
+/// the hypervisor from accessing memory it does not own.
 pub struct HypervisorMemoryProtector {}
 
 impl HypervisorMemoryProtector {
@@ -15,23 +15,31 @@ impl HypervisorMemoryProtector {
     }
 
     /// Configures the memory protection mechanism on the hart which executes this function.  
-    pub fn setup(&self) -> Result<(), Error> {
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that the `MemoryLayout` has been initialized.
+    pub unsafe fn setup(&self) -> Result<(), Error> {
         // We use RISC-V PMP mechanism to define that the confidential memory region is not accessible.
         // We use RISC-V IOPMP mechanism to ensure that no IO devices can access confidential memory region.
         let (confidential_memory_start, confidential_memory_end) = MemoryLayout::read().confidential_memory_boundary();
         pmp::split_memory_into_confidential_and_non_confidential(confidential_memory_start, confidential_memory_end)?;
         iopmp::protect_confidential_memory_from_io_devices(confidential_memory_start, confidential_memory_end)?;
 
+        // Enable memory isolation protection.
+        pmp::close_access_to_confidential_memory();
+        super::tlb::tlb_shutdown();
+
         Ok(())
     }
 
-    /// Reconfigures hardware to enable access initiated from this physical hart to memory regions
-    /// owned by the hypervisor and denies accesses to all other memory regions.
+    /// Reconfigures hardware to enable memory accesses initiated from this physical hart to memory regions owned by the
+    /// hypervisor and denies accesses to all other memory regions.
     ///
     /// # Safety
     ///
-    /// Caller must guarantee that the security monitor will transition in the finite state machine
-    /// to the `non-confidential flow` and eventually to the hypervisor code.
+    /// Caller must guarantee that the security monitor will transition in the finite state machine to the
+    /// `non-confidential flow` and eventually to the hypervisor code.
     pub unsafe fn enable(&self, hgatp: usize) {
         pmp::close_access_to_confidential_memory();
         mmu::enable_address_translation(hgatp);

--- a/security-monitor/src/core/memory_protector/mmu/mod.rs
+++ b/security-monitor/src/core/memory_protector/mmu/mod.rs
@@ -24,3 +24,14 @@ pub fn copy_mmu_configuration_from_non_confidential_memory(hgatp: Hgatp) -> Resu
 
     Ok(root_page_table)
 }
+
+pub fn enable_address_translation(hgatp: usize) {
+    // Enable MMU for HS,VS,VS,U modes. It is safe to invoke below code
+    // because we have access to this register (run in the M-mode) and
+    // hgatp is the content of the HGATP register calculated by the security monitor
+    // when recreating page tables of a confidential virtual machine that will
+    // get executed.
+    unsafe {
+        riscv::register::hgatp::write(hgatp);
+    };
+}

--- a/security-monitor/src/core/memory_protector/mmu/page_table.rs
+++ b/security-monitor/src/core/memory_protector/mmu/page_table.rs
@@ -8,6 +8,7 @@ use crate::core::memory_protector::mmu::page_table_entry::{
 use crate::core::memory_protector::mmu::page_table_memory::PageTableMemory;
 use crate::core::memory_protector::mmu::paging_system::{PageTableLevel, PagingSystem};
 use crate::core::memory_tracker::{MemoryTracker, SharedPage};
+use crate::core::transformations::ConfidentialVmVirtualAddress;
 use crate::error::Error;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -27,6 +28,10 @@ impl RootPageTable {
 
     pub fn map_shared_page(&mut self, shared_page: SharedPage) -> Result<(), Error> {
         self.page_table.map_shared_page(self.paging_system, shared_page)
+    }
+
+    pub fn unmap_shared_page(&mut self, address: ConfidentialVmVirtualAddress) -> Result<(), Error> {
+        self.page_table.unmap_shared_page(self.paging_system, address)
     }
 
     pub fn address(&self) -> usize {
@@ -145,8 +150,9 @@ impl PageTable {
         Ok(())
     }
 
-    pub fn unmap_shared_page(&mut self) -> Result<(), Error> {
-        // TODO: shutdown TLB after unmapping a shared page
+    pub fn unmap_shared_page(
+        &mut self, _paging_system: PagingSystem, _address: ConfidentialVmVirtualAddress,
+    ) -> Result<(), Error> {
         panic!("Unimplemented");
     }
 

--- a/security-monitor/src/core/memory_protector/mod.rs
+++ b/security-monitor/src/core/memory_protector/mod.rs
@@ -10,3 +10,4 @@ mod hypervisor_memory_protector;
 mod iopmp;
 mod mmu;
 mod pmp;
+mod tlb;

--- a/security-monitor/src/core/memory_protector/tlb/mod.rs
+++ b/security-monitor/src/core/memory_protector/tlb/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2023 IBM Corporation
+// SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
+// SPDX-License-Identifier: Apache-2.0
+
+pub fn tlb_shutdown() {
+    // TODO: implement TLB shutdown for a processor composed of multiple HARTs
+    unsafe {
+        core::arch::asm!("hfence.gvma");
+        core::arch::asm!("hfence.vvma");
+    };
+}

--- a/security-monitor/src/core/panic.rs
+++ b/security-monitor/src/core/panic.rs
@@ -3,10 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::core::memory_layout::MemoryLayout;
 
-/// This piece of code executes on a panic. Panic is a runtime error that
-/// indicates an implementation bug from which we cannot recover. Examples are
-/// integer overflow, asserts, explicit statements like panic!(), unwrap(),
-/// expect().
+/// This piece of code executes on a panic, which is a runtime error that indicates an implementation bug from which we
+/// cannot recover. Examples are integer overflow, asserts, explicit statements like panic!(), unwrap(), expect().
 ///
 /// This function halts all other harts in the system and clear the confidential memory.
 #[panic_handler]

--- a/security-monitor/src/core/transformations/mod.rs
+++ b/security-monitor/src/core/transformations/mod.rs
@@ -17,7 +17,7 @@ pub use sbi_vm_request::SbiVmRequest;
 pub use share_page_request::{ConfidentialVmVirtualAddress, SharePageRequest};
 pub use share_page_result::SharePageResult;
 pub use terminate_request::TerminateRequest;
-pub use trap_reason::TrapReason;
+pub use trap_reason::{AceExtension, BaseExtension, SbiExtension, TrapReason};
 
 mod convert_to_confidential_vm_request;
 mod guest_load_page_fault_request;

--- a/security-monitor/src/core/transformations/trap_reason.rs
+++ b/security-monitor/src/core/transformations/trap_reason.rs
@@ -6,33 +6,218 @@ use crate::core::hart::{GpRegister, HartState};
 #[derive(Debug)]
 pub enum TrapReason {
     Interrupt,
-    VsEcall(usize, usize),
-    HsEcall(usize, usize),
+    VsEcall(SbiExtension),
+    HsEcall(SbiExtension),
     GuestLoadPageFault,
     GuestStorePageFault,
     StoreAccessFault,
-    Unknown(usize, usize),
+    Unknown,
 }
 
 impl TrapReason {
+    // Below constants are defined in the RISC-V privilege spec. See the table defining
+    // the machine cause register (mcause) values after trap.
     const STORE_ACCESS_FAULT: usize = 7;
     const HS_ECALL: usize = 9;
     const VS_ECALL: usize = 10;
     const GUEST_LOAD_PAGE_FAULT: usize = 21;
     const GUEST_STORE_PAGE_FAULT: usize = 23;
 
-    pub fn from_hart_state(hart_state: &HartState) -> TrapReason {
+    pub fn from_hart_state(hart_state: &HartState) -> Self {
         let mcause = riscv::register::mcause::read();
         if mcause.is_interrupt() {
-            return TrapReason::Interrupt;
+            return Self::Interrupt;
         }
         match mcause.code() {
-            Self::STORE_ACCESS_FAULT => TrapReason::StoreAccessFault,
-            Self::HS_ECALL => TrapReason::HsEcall(hart_state.gpr(GpRegister::a7), hart_state.gpr(GpRegister::a6)),
-            Self::VS_ECALL => TrapReason::VsEcall(hart_state.gpr(GpRegister::a7), hart_state.gpr(GpRegister::a6)),
-            Self::GUEST_LOAD_PAGE_FAULT => TrapReason::GuestLoadPageFault,
-            Self::GUEST_STORE_PAGE_FAULT => TrapReason::GuestStorePageFault,
-            _ => TrapReason::Unknown(hart_state.gpr(GpRegister::a7), hart_state.gpr(GpRegister::a6)),
+            Self::STORE_ACCESS_FAULT => Self::StoreAccessFault,
+            Self::HS_ECALL => Self::HsEcall(SbiExtension::decode(hart_state)),
+            Self::VS_ECALL => Self::VsEcall(SbiExtension::decode(hart_state)),
+            Self::GUEST_LOAD_PAGE_FAULT => Self::GuestLoadPageFault,
+            Self::GUEST_STORE_PAGE_FAULT => Self::GuestStorePageFault,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum SbiExtension {
+    Ace(AceExtension),
+    Base(BaseExtension),
+    Timer(TimerExtension),
+    Ipi(IpiExtension),
+    Rfence(RfenceExtension),
+    Hsm(HsmExtension),
+    Srst(SrstExtension),
+    Unknown(usize, usize),
+}
+
+impl SbiExtension {
+    fn decode(hart_state: &HartState) -> Self {
+        match (hart_state.gpr(GpRegister::a7), hart_state.gpr(GpRegister::a6)) {
+            (AceExtension::EXTID, function_id) => Self::Ace(AceExtension::from_function_id(function_id)),
+            (BaseExtension::EXTID, function_id) => Self::Base(BaseExtension::from_function_id(function_id)),
+            (TimerExtension::EXTID, function_id) => Self::Timer(TimerExtension::from_function_id(function_id)),
+            (IpiExtension::EXTID, function_id) => Self::Ipi(IpiExtension::from_function_id(function_id)),
+            (RfenceExtension::EXTID, function_id) => Self::Rfence(RfenceExtension::from_function_id(function_id)),
+            (HsmExtension::EXTID, function_id) => Self::Hsm(HsmExtension::from_function_id(function_id)),
+            (SrstExtension::EXTID, function_id) => Self::Srst(SrstExtension::from_function_id(function_id)),
+            (extension_id, function_id) => Self::Unknown(extension_id, function_id),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum AceExtension {
+    SharePageWithHypervisor,
+    ConvertToConfidentialVm,
+    ResumeConfidentialHart,
+    TerminateConfidentialVm,
+    Unknown(usize, usize),
+}
+
+impl AceExtension {
+    // TODO: replace with an identifier registered in the RISC-V fundation
+    pub const EXTID: usize = 0x510000;
+
+    pub fn from_function_id(function_id: usize) -> Self {
+        match function_id {
+            2000 => Self::SharePageWithHypervisor,
+            1000 => Self::ConvertToConfidentialVm,
+            1010 => Self::ResumeConfidentialHart,
+            3001 => Self::TerminateConfidentialVm,
+            _ => Self::Unknown(Self::EXTID, function_id),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum BaseExtension {
+    GetSpecVersion,
+    GetImplId,
+    GetImplVersion,
+    ProbeExtension,
+    GetMvendorId,
+    GetMarchid,
+    GetMimpid,
+    Unknown(usize, usize),
+}
+
+impl BaseExtension {
+    pub const EXTID: usize = 0x10;
+
+    pub fn from_function_id(function_id: usize) -> Self {
+        match function_id {
+            0 => Self::GetSpecVersion,
+            1 => Self::GetImplId,
+            2 => Self::GetImplVersion,
+            3 => Self::ProbeExtension,
+            4 => Self::GetMvendorId,
+            5 => Self::GetMarchid,
+            6 => Self::GetMimpid,
+            _ => Self::Unknown(Self::EXTID, function_id),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum TimerExtension {
+    SetTimer,
+    Unknown(usize, usize),
+}
+
+impl TimerExtension {
+    pub const EXTID: usize = 0x54494D45;
+
+    pub fn from_function_id(function_id: usize) -> Self {
+        match function_id {
+            0 => Self::SetTimer,
+            _ => Self::Unknown(Self::EXTID, function_id),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum IpiExtension {
+    SendIpi,
+    Unknown(usize, usize),
+}
+
+impl IpiExtension {
+    pub const EXTID: usize = 0x735049;
+
+    pub fn from_function_id(function_id: usize) -> Self {
+        match function_id {
+            0 => Self::SendIpi,
+            _ => Self::Unknown(Self::EXTID, function_id),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum RfenceExtension {
+    RemoteFenceI,
+    RemoteFenceVma,
+    RemoteFenceVmaAsid,
+    RemoteFenceGvmaVmid,
+    RemoteFenceGvma,
+    RemoteFenceVvmaAsid,
+    RemoteFenceVvma,
+    Unknown(usize, usize),
+}
+
+impl RfenceExtension {
+    pub const EXTID: usize = 0x52464E43;
+
+    pub fn from_function_id(function_id: usize) -> Self {
+        match function_id {
+            0 => Self::RemoteFenceI,
+            1 => Self::RemoteFenceVma,
+            2 => Self::RemoteFenceVmaAsid,
+            3 => Self::RemoteFenceGvmaVmid,
+            4 => Self::RemoteFenceGvma,
+            5 => Self::RemoteFenceVvmaAsid,
+            6 => Self::RemoteFenceVvma,
+            _ => Self::Unknown(Self::EXTID, function_id),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum HsmExtension {
+    HartStart,
+    HartStop,
+    HartGetStatus,
+    HartSuspend,
+    Unknown(usize, usize),
+}
+
+impl HsmExtension {
+    pub const EXTID: usize = 0x48534D;
+
+    pub fn from_function_id(function_id: usize) -> Self {
+        match function_id {
+            0 => Self::HartStart,
+            1 => Self::HartStop,
+            2 => Self::HartGetStatus,
+            3 => Self::HartSuspend,
+            _ => Self::Unknown(Self::EXTID, function_id),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum SrstExtension {
+    SystemReset,
+    Unknown(usize, usize),
+}
+
+impl SrstExtension {
+    pub const EXTID: usize = 0x53525354;
+
+    pub fn from_function_id(function_id: usize) -> Self {
+        match function_id {
+            0 => Self::SystemReset,
+            _ => Self::Unknown(Self::EXTID, function_id),
         }
     }
 }

--- a/security-monitor/src/error.rs
+++ b/security-monitor/src/error.rs
@@ -56,8 +56,8 @@ pub enum Error {
     InvalidRiscvInstruction(usize),
     #[error("Not supported interrupt")]
     NotSupportedInterrupt(),
-    #[error("Invalid call cause: {0}, extid: {1:x}, fid: {2:x}")]
-    InvalidCall(usize, usize, usize),
+    #[error("Invalid call cause: {0}")]
+    InvalidCall(usize),
     #[error("Internal error")]
     Pointer(#[from] PointerError),
 }

--- a/security-monitor/src/lib.rs
+++ b/security-monitor/src/lib.rs
@@ -33,6 +33,3 @@ mod confidential_flow;
 mod core;
 mod error;
 mod non_confidential_flow;
-
-// TODO: replace with an identifier registered in the RISC-V fundation
-const ACE_EXT_ID: usize = 0x510000;

--- a/security-monitor/src/lib.rs
+++ b/security-monitor/src/lib.rs
@@ -21,12 +21,8 @@
 #![register_tool(rr)]
 #![feature(custom_inner_attributes)]
 
-// extern creates
 extern crate alloc;
-// pub use declarations
-// use declarations
-// pub mod declarations
-// mod declarations
+
 #[macro_use]
 mod debug;
 mod confidential_flow;

--- a/security-monitor/src/non_confidential_flow/handlers/invalid_call.rs
+++ b/security-monitor/src/non_confidential_flow/handlers/invalid_call.rs
@@ -4,9 +4,8 @@
 use crate::error::Error;
 use crate::non_confidential_flow::NonConfidentialFlow;
 
-pub fn handle(non_confidential_flow: NonConfidentialFlow, extension_id: usize, function_id: usize) -> ! {
+pub fn handle(non_confidential_flow: NonConfidentialFlow) -> ! {
     let mcause = riscv::register::mcause::read().code();
-    let transformation = Error::InvalidCall(mcause, extension_id, function_id).into_non_confidential_transformation();
-
+    let transformation = Error::InvalidCall(mcause).into_non_confidential_transformation();
     non_confidential_flow.exit_to_hypervisor(transformation)
 }


### PR DESCRIPTION
To support Linux-based CVM, the security monitor must enable certain hypercalls. This PR defines all ratified SBI extensions and provides a passthrough support for SBI functions within the base extension.