### PR TITLE
Early support for the SBI HSM extension

### DIFF
--- a/confidential-vms/baremetal/src/uart.rs
+++ b/confidential-vms/baremetal/src/uart.rs
@@ -46,6 +46,7 @@ impl Uart {
     }
 
     pub fn println(&mut self, out: &str) {
+        use alloc::format;
         crate::sync::acquire(crate::sync::UART_SYNC_ADDRESS);
         for c in out.bytes() {
             self.put(c);

--- a/confidential-vms/baremetal/src/worker.rs
+++ b/confidential-vms/baremetal/src/worker.rs
@@ -28,6 +28,10 @@ extern "C" fn worker_init(hart_id: usize) {
         riscv::register::sstatus::set_sie();
     }
 
+    loop {
+        uart.println(&format!("Hello from hart id: {}", hart_id));
+    }
+
     sbi::system_reset::system_reset(
         sbi::system_reset::ResetType::Shutdown,
         sbi::system_reset::ResetReason::NoReason,

--- a/security-monitor/src/confidential_flow/handlers/mod.rs
+++ b/security-monitor/src/confidential_flow/handlers/mod.rs
@@ -11,5 +11,8 @@ pub mod inter_hart_request;
 pub mod interrupt;
 pub mod invalid_call;
 pub mod sbi_hsm_hart_start;
+pub mod sbi_hsm_hart_stop;
+pub mod sbi_hsm_hart_suspend;
+pub mod sbi_srst;
 pub mod share_page;
 pub mod share_page_result;

--- a/security-monitor/src/confidential_flow/handlers/sbi_hsm_hart_start.rs
+++ b/security-monitor/src/confidential_flow/handlers/sbi_hsm_hart_start.rs
@@ -2,21 +2,27 @@
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
 use crate::confidential_flow::ConfidentialFlow;
-use crate::core::control_data::ControlData;
-use crate::core::transformations::{ExposeToHypervisor, InterHartRequest, PendingRequest, SbiHsmHartStart, SbiRequest};
+use crate::core::architecture::HartLifecycleStateTransition;
+use crate::core::transformations::{ExposeToHypervisor, PendingRequest, SbiHsmHartStart, SbiRequest};
 
-/// Handles HartStart function from the HSM extension of SBI.
-pub fn handle(request: SbiHsmHartStart, confidential_flow: ConfidentialFlow) -> ! {
+/// Starts a confidential hart. This is an implementation of the HartStart function from the HSM extension of SBI.
+///
+/// This call is triggered by a confidential hart that wants to start another confidential hart. Error is returned to
+/// the caller if the targetted confidential hart is not in the stopped state or it does not exist. The security monitor
+/// moves targetted confidential harts into `StartPending` state and informs then the hypervisor that these harts are
+/// runnable. Once the hypervisor schedules such a confidential hart for execution, the confidential hart will change
+/// the state to `Started`.
+pub fn handle(request: SbiHsmHartStart, mut confidential_flow: ConfidentialFlow) -> ! {
     let confidential_hart_id = request.confidential_hart_id;
-    // TODO: we must check the state of the hart and only allow starting a HART that is in the shutdown state
-    match ControlData::try_confidential_vm_mut(confidential_flow.confidential_vm_id(), |ref mut confidential_vm| {
-        Ok(confidential_vm.add_inter_hart_request(InterHartRequest::SbiHsmHartStart(request)))
-    }) {
+    match confidential_flow.transit_hart_lifecycle(HartLifecycleStateTransition::StoppedToStartPending(request)) {
         Ok(_) => confidential_flow
-            .set_pending_request(PendingRequest::SbiRequest())
+            .set_pending_request(PendingRequest::SbiHsmHartStart())
             .into_non_confidential_flow()
             .exit_to_hypervisor(ExposeToHypervisor::SbiRequest(SbiRequest::kvm_hsm_hart_start(confidential_hart_id))),
         Err(error) => {
+            // starting a confidential hart might fail if the incoming request is invalid. For example, the confidential
+            // hart id does not exist or is the same as the one currently assigned to the hardware hart. In such cases,
+            // return an error to the calling confidential hart.
             confidential_flow.exit_to_confidential_vm(error.into_confidential_transformation());
         }
     }

--- a/security-monitor/src/confidential_flow/handlers/sbi_hsm_hart_stop.rs
+++ b/security-monitor/src/confidential_flow/handlers/sbi_hsm_hart_stop.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2023 IBM Corporation
+// SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
+// SPDX-License-Identifier: Apache-2.0
+use crate::confidential_flow::ConfidentialFlow;
+use crate::core::architecture::HartLifecycleStateTransition;
+use crate::core::transformations::{ExposeToHypervisor, SbiRequest};
+
+/// Stops the confidential hart as defined in the HSM extension of SBI. Error is returned to the confidential hart if
+/// the security monitor cannot stop it, for example, because it is not in the started state.
+///
+/// The request to stop the confidential hart comes from the confidential hart itself. The security monitor stops the
+/// hart and informs the hypervisor that the hart has been stopped. The hypervisor should not resume execution of a
+/// stopped confidential hart. Only another confidential hart of the confidential VM can start the confidential hart.
+pub fn handle(mut confidential_flow: ConfidentialFlow) -> ! {
+    match confidential_flow.transit_hart_lifecycle(HartLifecycleStateTransition::StartedToStopped()) {
+        Ok(_) => confidential_flow
+            .into_non_confidential_flow()
+            .exit_to_hypervisor(ExposeToHypervisor::SbiRequest(SbiRequest::kvm_hsm_hart_stop())),
+        Err(error) => confidential_flow.exit_to_confidential_vm(error.into_confidential_transformation()),
+    }
+}

--- a/security-monitor/src/confidential_flow/handlers/sbi_hsm_hart_suspend.rs
+++ b/security-monitor/src/confidential_flow/handlers/sbi_hsm_hart_suspend.rs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2023 IBM Corporation
+// SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
+// SPDX-License-Identifier: Apache-2.0
+use crate::confidential_flow::ConfidentialFlow;
+use crate::core::architecture::HartLifecycleStateTransition;
+use crate::core::transformations::{ExposeToHypervisor, SbiHsmHartSuspend, SbiRequest};
+
+/// Suspends a confidential hart that made this request. This is an implementation of the HartSuspend function from the
+/// HSM extension of SBI.
+///
+/// The request to suspend the confidential hart comes frmo the confidential hart itself. The security monitor suspends
+/// the confidential hart and informs about it the hypervisor. This functions returns an error to the calling
+/// confidential hart if this confidential hart cannot be suspended, for example, because it is not in the started
+/// state.
+pub fn handle(request: SbiHsmHartSuspend, mut confidential_flow: ConfidentialFlow) -> ! {
+    match confidential_flow.transit_hart_lifecycle(HartLifecycleStateTransition::StartedToSuspended(request)) {
+        Ok(_) => confidential_flow
+            .into_non_confidential_flow()
+            .exit_to_hypervisor(ExposeToHypervisor::SbiRequest(SbiRequest::kvm_hsm_hart_suspend())),
+        Err(error) => confidential_flow.exit_to_confidential_vm(error.into_confidential_transformation()),
+    }
+}

--- a/security-monitor/src/confidential_flow/handlers/sbi_srst.rs
+++ b/security-monitor/src/confidential_flow/handlers/sbi_srst.rs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2023 IBM Corporation
+// SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
+// SPDX-License-Identifier: Apache-2.0
+use crate::confidential_flow::ConfidentialFlow;
+use crate::core::control_data::ControlData;
+use crate::core::transformations::{ExposeToHypervisor, SbiRequest};
+
+pub fn handle(request: SbiRequest, confidential_flow: ConfidentialFlow) -> ! {
+    let confidential_vm_id = confidential_flow.confidential_vm_id();
+    match ControlData::try_write(|control_data| control_data.remove_confidential_vm(confidential_vm_id)) {
+        Ok(_) => {
+            confidential_flow.into_non_confidential_flow().exit_to_hypervisor(ExposeToHypervisor::SbiRequest(request))
+        }
+        Err(error) => confidential_flow.exit_to_confidential_vm(error.into_confidential_transformation()),
+    }
+}

--- a/security-monitor/src/confidential_flow/handlers/share_page.rs
+++ b/security-monitor/src/confidential_flow/handlers/share_page.rs
@@ -14,7 +14,7 @@ pub fn handle(request: Result<(SharePageRequest, SbiRequest), Error>, confidenti
     match request {
         Ok((share_page_request, sbi_request)) => {
             debug!(
-                "Confidential VM[confidential_vm_id={:?}] requested a shared page mapped to address [guest_physical_address={:?}]",
+                "Confidential VM[{:?}] requested a shared page mapped to address [{:?}]",
                 confidential_flow.confidential_vm_id(),
                 share_page_request.confidential_vm_virtual_address()
             );

--- a/security-monitor/src/confidential_flow/handlers/share_page_result.rs
+++ b/security-monitor/src/confidential_flow/handlers/share_page_result.rs
@@ -25,8 +25,9 @@ pub fn handle(share_page_result: SharePageResult, confidential_flow: Confidentia
     };
 
     debug!(
-        "Hypervisor shared a page with the confidential VM [confidential_vm_id={:?}] at address [physical address=0x{:x}]",
-        confidential_vm_id, share_page_result.hypervisor_page_address()
+        "Hypervisor shared a page with the confidential VM [{:?}] at address [physical address=0x{:x}]",
+        confidential_vm_id,
+        share_page_result.hypervisor_page_address()
     );
 
     let transformation = ControlData::try_confidential_vm_mut(confidential_vm_id, |mut confidential_vm| {

--- a/security-monitor/src/core/architecture/mod.rs
+++ b/security-monitor/src/core/architecture/mod.rs
@@ -2,8 +2,9 @@
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
 pub use riscv::{
-    decode_result_register, AceExtension, BaseExtension, FpRegisters, GpRegister, GpRegisters, HartState, HsmExtension,
-    IpiExtension, RfenceExtension, SbiExtension, SrstExtension, TrapReason,
+    decode_result_register, AceExtension, BaseExtension, FpRegisters, GpRegister, GpRegisters, HartArchitecturalState,
+    HartLifecycleState, HartLifecycleStateTransition, HsmExtension, IpiExtension, RfenceExtension, SbiExtension,
+    SrstExtension, TrapReason,
 };
 
 mod riscv;

--- a/security-monitor/src/core/architecture/riscv/hart_architectural_state.rs
+++ b/security-monitor/src/core/architecture/riscv/hart_architectural_state.rs
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::core::architecture::{FpRegisters, GpRegister, GpRegisters, TrapReason};
 
-/// HartState is the dump state of the processor's core, called in RISC-V a hardware thread (HART).
+/// HartArchitecturalState is the dump state of the processor's core, called in RISC-V a hardware thread (HART).
 #[repr(C)]
-pub struct HartState {
-    // gprs must be the first element in this structure because it is used to calculate the HartState address in the
-    // memory. This address is used by the assembly code.
+pub struct HartArchitecturalState {
+    // gprs must be the first element in this structure because it is used to calculate the HartArchitecturalState
+    // address in the memory. This address is used by the assembly code.
     pub gprs: GpRegisters,
     // floating-point related
     pub fprs: FpRegisters,
@@ -54,9 +54,9 @@ pub struct HartState {
     pub mtval2: usize,
 }
 
-impl HartState {
-    pub fn from_existing(id: usize, existing: &HartState) -> HartState {
-        HartState {
+impl HartArchitecturalState {
+    pub fn from_existing(id: usize, existing: &HartArchitecturalState) -> HartArchitecturalState {
+        HartArchitecturalState {
             id,
             gprs: existing.gprs.clone(),
             // M-mode
@@ -102,8 +102,8 @@ impl HartState {
         }
     }
 
-    pub fn empty(id: usize) -> HartState {
-        HartState {
+    pub fn empty(id: usize) -> HartArchitecturalState {
+        HartArchitecturalState {
             id,
             gprs: GpRegisters::empty(),
             sstatus: 0,
@@ -145,7 +145,7 @@ impl HartState {
     }
 }
 
-impl HartState {
+impl HartArchitecturalState {
     pub fn gpr(&self, register: GpRegister) -> usize {
         self.gprs.get(register)
     }
@@ -154,12 +154,33 @@ impl HartState {
         self.gprs.set(register, value)
     }
 
+    pub fn reset(&mut self) {
+        self.gprs = GpRegisters::empty();
+        self.fprs = FpRegisters::empty();
+        self.fcsr = 0;
+        self.htinst = 0;
+        self.htval = 0;
+        self.sepc = 0;
+        self.scounteren = 0;
+        self.vsie = 0;
+        self.vstvec = 0;
+        self.vsscratch = 0;
+        self.vsepc = 0;
+        self.vscause = 0;
+        self.vstval = 0;
+        self.hvip = 0;
+        self.vsatp = 0;
+        // TODO: what should be the sstatus on reset?
+        // self.sstatus = 0;
+        self.vsstatus = 0;
+    }
+
     pub fn trap_reason(&self) -> TrapReason {
         TrapReason::from_hart_state(self)
     }
 }
 
-impl core::fmt::Debug for HartState {
+impl core::fmt::Debug for HartArchitecturalState {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "hart_id: {}, ", self.id)?;
         GpRegisters::iter().try_for_each(|x| -> core::fmt::Result {

--- a/security-monitor/src/core/architecture/riscv/hart_lifecycle_state.rs
+++ b/security-monitor/src/core/architecture/riscv/hart_lifecycle_state.rs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2023 IBM Corporation
+// SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
+// SPDX-License-Identifier: Apache-2.0
+
+/// Hart lifecycle states as documented in the SBI specification of the HSM extension.
+#[derive(PartialEq)]
+pub enum HartLifecycleState {
+    Started,
+    Stopped,
+    StartPending,
+    //
+    // StopPending is never used because the security monitor stops the hart directly and only informs a hypervisor
+    // about it for the bookkeeping pourposes.
+    // StopPending,
+    Suspended,
+    //
+    // SuspendPending is never used because the security monitor stops the hart directly and only informs a hypervisor
+    // about it for the bookkeeping pourposes.
+    // SuspendPending,
+    //
+    // ResumePending is never used because the security monitor stops the hart directly and only informs a hypervisor
+    // about it for the bookkeeping pourposes.
+    // ResumePending,
+}

--- a/security-monitor/src/core/architecture/riscv/hart_lifecycle_state_transition.rs
+++ b/security-monitor/src/core/architecture/riscv/hart_lifecycle_state_transition.rs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2023 IBM Corporation
+// SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
+// SPDX-License-Identifier: Apache-2.0
+use crate::core::transformations::{SbiHsmHartStart, SbiHsmHartSuspend};
+
+pub enum HartLifecycleStateTransition {
+    StoppedToStartPending(SbiHsmHartStart),
+    StartedToSuspended(SbiHsmHartSuspend),
+    SuspendedToStarted(),
+    StartedToStopped(),
+}

--- a/security-monitor/src/core/architecture/riscv/mod.rs
+++ b/security-monitor/src/core/architecture/riscv/mod.rs
@@ -4,13 +4,17 @@
 pub use compressed_instructions::decode_result_register;
 pub use fp_registers::FpRegisters;
 pub use gp_registers::{GpRegister, GpRegisters};
-pub use hart_state::HartState;
+pub use hart_architectural_state::HartArchitecturalState;
+pub use hart_lifecycle_state::HartLifecycleState;
+pub use hart_lifecycle_state_transition::HartLifecycleStateTransition;
 pub use sbi::{AceExtension, BaseExtension, HsmExtension, IpiExtension, RfenceExtension, SbiExtension, SrstExtension};
 pub use trap_reason::TrapReason;
 
 mod compressed_instructions;
 mod fp_registers;
 mod gp_registers;
-mod hart_state;
+mod hart_architectural_state;
+mod hart_lifecycle_state;
+mod hart_lifecycle_state_transition;
 mod sbi;
 mod trap_reason;

--- a/security-monitor/src/core/architecture/riscv/sbi.rs
+++ b/security-monitor/src/core/architecture/riscv/sbi.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::architecture::{GpRegister, HartState};
+use crate::core::architecture::{GpRegister, HartArchitecturalState};
 
 #[derive(Debug)]
 pub enum SbiExtension {
@@ -16,7 +16,7 @@ pub enum SbiExtension {
 }
 
 impl SbiExtension {
-    pub fn decode(hart_state: &HartState) -> Self {
+    pub fn decode(hart_state: &HartArchitecturalState) -> Self {
         match (hart_state.gpr(GpRegister::a7), hart_state.gpr(GpRegister::a6)) {
             (AceExtension::EXTID, function_id) => Self::Ace(AceExtension::from_function_id(function_id)),
             (BaseExtension::EXTID, function_id) => Self::Base(BaseExtension::from_function_id(function_id)),

--- a/security-monitor/src/core/architecture/riscv/trap_reason.rs
+++ b/security-monitor/src/core/architecture/riscv/trap_reason.rs
@@ -2,7 +2,7 @@
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
 use crate::core::architecture::riscv::sbi::SbiExtension;
-use crate::core::architecture::HartState;
+use crate::core::architecture::HartArchitecturalState;
 
 #[derive(Debug)]
 pub enum TrapReason {
@@ -24,7 +24,7 @@ impl TrapReason {
     const GUEST_LOAD_PAGE_FAULT: usize = 21;
     const GUEST_STORE_PAGE_FAULT: usize = 23;
 
-    pub fn from_hart_state(hart_state: &HartState) -> Self {
+    pub fn from_hart_state(hart_state: &HartArchitecturalState) -> Self {
         let mcause = riscv::register::mcause::read();
         if mcause.is_interrupt() {
             return Self::Interrupt;

--- a/security-monitor/src/core/control_data/confidential_vm_id.rs
+++ b/security-monitor/src/core/control_data/confidential_vm_id.rs
@@ -17,6 +17,6 @@ impl ConfidentialVmId {
 
 impl core::fmt::Debug for ConfidentialVmId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "[confidential_vm_id={:x}]", self.0)
+        write!(f, "confidential_vm_id={:x}", self.0)
     }
 }

--- a/security-monitor/src/core/control_data/hardware_hart.rs
+++ b/security-monitor/src/core/control_data/hardware_hart.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::architecture::{GpRegister, HartState, TrapReason};
+use crate::core::architecture::{GpRegister, HartArchitecturalState, TrapReason};
 use crate::core::control_data::ConfidentialHart;
 use crate::core::memory_protector::HypervisorMemoryProtector;
 use crate::core::page_allocator::{Allocated, Page, UnAllocated};
@@ -13,9 +13,9 @@ use crate::core::transformations::{
 
 #[repr(C)]
 pub struct HardwareHart {
-    // Careful, HardwareHart and ConfidentialHart must both start with the HartState element because based on this we
-    // automatically calculate offsets of registers' and CSRs' for the asm code.
-    pub(super) non_confidential_hart_state: HartState,
+    // Careful, HardwareHart and ConfidentialHart must both start with the HartArchitecturalState element because based
+    // on this we automatically calculate offsets of registers' and CSRs' for the asm code.
+    pub(super) non_confidential_hart_state: HartArchitecturalState,
     // Memory protector that configures the hardware memory isolation component to allow only memory accesses
     // to the memory region owned by the hypervisor.
     hypervisor_memory_protector: HypervisorMemoryProtector,
@@ -38,7 +38,7 @@ pub struct HardwareHart {
 impl HardwareHart {
     pub fn init(id: usize, stack: Page<UnAllocated>, hypervisor_memory_protector: HypervisorMemoryProtector) -> Self {
         Self {
-            non_confidential_hart_state: HartState::empty(id),
+            non_confidential_hart_state: HartArchitecturalState::empty(id),
             hypervisor_memory_protector,
             stack_address: stack.end_address(),
             stack: stack.zeroize(),

--- a/security-monitor/src/core/control_data/mod.rs
+++ b/security-monitor/src/core/control_data/mod.rs
@@ -8,7 +8,7 @@ pub use confidential_vm_measurement::ConfidentialVmMeasurement;
 pub use hardware_hart::HardwareHart;
 pub use storage::{ControlData, CONTROL_DATA};
 
-use crate::core::architecture::{GpRegister, HartState};
+use crate::core::architecture::{GpRegister, HartArchitecturalState};
 
 mod confidential_hart;
 mod confidential_vm;
@@ -19,19 +19,20 @@ mod storage;
 
 const fn hart_gpr_offset(index: GpRegister) -> usize {
     memoffset::offset_of!(HardwareHart, non_confidential_hart_state)
-        + memoffset::offset_of!(HartState, gprs)
+        + memoffset::offset_of!(HartArchitecturalState, gprs)
         + (index as usize) * core::mem::size_of::<u64>()
 }
 
 const fn hart_fpr_offset(index: usize) -> usize {
     memoffset::offset_of!(HardwareHart, non_confidential_hart_state)
-        + memoffset::offset_of!(HartState, fprs)
+        + memoffset::offset_of!(HartArchitecturalState, fprs)
         + index * core::mem::size_of::<u64>()
 }
 
 macro_rules! hart_csr_offset {
     ($reg:tt) => {
-        memoffset::offset_of!(HardwareHart, non_confidential_hart_state) + memoffset::offset_of!(HartState, $reg)
+        memoffset::offset_of!(HardwareHart, non_confidential_hart_state)
+            + memoffset::offset_of!(HartArchitecturalState, $reg)
     };
 }
 

--- a/security-monitor/src/core/control_data/storage.rs
+++ b/security-monitor/src/core/control_data/storage.rs
@@ -50,6 +50,7 @@ impl ControlData {
     pub fn remove_confidential_vm(
         &mut self, confidential_vm_id: ConfidentialVmId,
     ) -> Result<Mutex<ConfidentialVm>, Error> {
+        assure_not!(self.confidential_vm(confidential_vm_id)?.is_running(), Error::HartAlreadyRunning())?;
         self.confidential_vms.remove(&confidential_vm_id).ok_or(Error::InvalidConfidentialVmId())
     }
 

--- a/security-monitor/src/core/memory_layout/confidential_vm_virtual_address.rs
+++ b/security-monitor/src/core/memory_layout/confidential_vm_virtual_address.rs
@@ -17,6 +17,6 @@ impl ConfidentialVmVirtualAddress {
 
 impl core::fmt::Debug for ConfidentialVmVirtualAddress {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "[confidential_vm_virtual_address={:x}]", self.0)
+        write!(f, "confidential_vm_virtual_address={:x}", self.0)
     }
 }

--- a/security-monitor/src/core/memory_protector/confidential_vm_memory_protector.rs
+++ b/security-monitor/src/core/memory_protector/confidential_vm_memory_protector.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::architecture::HartState;
+use crate::core::architecture::HartArchitecturalState;
 use crate::core::control_data::ConfidentialVmId;
 use crate::core::memory_layout::ConfidentialVmVirtualAddress;
 use crate::core::memory_protector::mmu::RootPageTable;
@@ -23,7 +23,7 @@ impl ConfidentialVmMemoryProtector {
     /// Constructs the memory protector of a confidential VM from the dumped state of a hart that was running a
     /// non-confidential VM at the time it requested to be converted in a confidential VM. This function copies the
     /// entire configuration of the underlying hardware memory isolation component into the confidential memory.
-    pub fn from_vm_state(hart_state: &HartState) -> Result<Self, Error> {
+    pub fn from_vm_state(hart_state: &HartArchitecturalState) -> Result<Self, Error> {
         let hgatp = Hgatp::from(hart_state.hgatp);
         let root_page_table = mmu::copy_mmu_configuration_from_non_confidential_memory(hgatp)?;
 

--- a/security-monitor/src/core/transformations/convert_to_confidential_vm_request.rs
+++ b/security-monitor/src/core/transformations/convert_to_confidential_vm_request.rs
@@ -1,19 +1,19 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::architecture::HartState;
+use crate::core::architecture::HartArchitecturalState;
 
 pub struct ConvertToConfidentialVm {
-    hart_state: HartState,
+    hart_state: HartArchitecturalState,
 }
 
 impl ConvertToConfidentialVm {
-    pub fn new(from_state: &HartState) -> Self {
-        let hart_state = HartState::from_existing(0, from_state);
+    pub fn new(from_state: &HartArchitecturalState) -> Self {
+        let hart_state = HartArchitecturalState::from_existing(0, from_state);
         Self { hart_state }
     }
 
-    pub fn into(self) -> HartState {
+    pub fn into(self) -> HartArchitecturalState {
         self.hart_state
     }
 }

--- a/security-monitor/src/core/transformations/guest_load_page_fault_result.rs
+++ b/security-monitor/src/core/transformations/guest_load_page_fault_result.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::architecture::{GpRegister, HartState};
+use crate::core::architecture::{GpRegister, HartArchitecturalState};
 use crate::core::transformations::GuestLoadPageFaultRequest;
 
 pub struct GuestLoadPageFaultResult {
@@ -11,7 +11,7 @@ pub struct GuestLoadPageFaultResult {
 }
 
 impl GuestLoadPageFaultResult {
-    pub fn new(hart_state: &HartState, request: GuestLoadPageFaultRequest) -> Self {
+    pub fn new(hart_state: &HartArchitecturalState, request: GuestLoadPageFaultRequest) -> Self {
         Self {
             result_gpr: request.result_gpr(),
             value: hart_state.gpr(request.result_gpr()),

--- a/security-monitor/src/core/transformations/opensbi_request.rs
+++ b/security-monitor/src/core/transformations/opensbi_request.rs
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::architecture::{GpRegister, HartState};
+use crate::core::architecture::{GpRegister, HartArchitecturalState};
 
 pub struct OpensbiRequest {
     pub regs: opensbi_sys::sbi_trap_regs,
 }
 
 impl OpensbiRequest {
-    pub fn new(hart_state: &HartState) -> Self {
+    pub fn new(hart_state: &HartArchitecturalState) -> Self {
         Self {
             regs: opensbi_sys::sbi_trap_regs {
                 zero: 0,

--- a/security-monitor/src/core/transformations/sbi_hsm.rs
+++ b/security-monitor/src/core/transformations/sbi_hsm.rs
@@ -5,12 +5,25 @@
 #[derive(PartialEq, Debug, Clone)]
 pub struct SbiHsmHartStart {
     pub confidential_hart_id: usize,
-    pub boot_code_address: usize,
-    pub blob: usize,
+    pub start_address: usize,
+    pub opaque: usize,
 }
 
 impl SbiHsmHartStart {
-    pub fn new(confidential_hart_id: usize, boot_code_address: usize, blob: usize) -> Self {
-        Self { confidential_hart_id, boot_code_address, blob }
+    pub fn new(confidential_hart_id: usize, start_address: usize, opaque: usize) -> Self {
+        Self { confidential_hart_id, start_address, opaque }
+    }
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct SbiHsmHartSuspend {
+    pub suspend_type: usize,
+    pub resume_address: usize,
+    pub opaque: usize,
+}
+
+impl SbiHsmHartSuspend {
+    pub fn new(suspend_type: usize, resume_address: usize, opaque: usize) -> Self {
+        Self { suspend_type, resume_address, opaque }
     }
 }

--- a/security-monitor/src/core/transformations/sbi_request.rs
+++ b/security-monitor/src/core/transformations/sbi_request.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::architecture::{GpRegister, HartState};
+use crate::core::architecture::{GpRegister, HartArchitecturalState};
 use crate::core::control_data::ConfidentialVmId;
 
 pub struct SbiRequest {
@@ -42,9 +42,19 @@ impl SbiRequest {
         Self::new(HsmExtension::EXTID, HsmExtension::HART_START_FID, virtual_hart_id, 0, 0, 0, 0, 0)
     }
 
-    // only ConfidentialHart or HardwareHart can invoke this function because only they have access to the HartState
-    // storing confidential information
-    pub fn from_hart_state(hart_state: &HartState) -> Self {
+    pub fn kvm_hsm_hart_stop() -> Self {
+        use crate::core::architecture::HsmExtension;
+        Self::new(HsmExtension::EXTID, HsmExtension::HART_STOP_FID, 0, 0, 0, 0, 0, 0)
+    }
+
+    pub fn kvm_hsm_hart_suspend() -> Self {
+        use crate::core::architecture::HsmExtension;
+        Self::new(HsmExtension::EXTID, HsmExtension::HART_SUSPEND_FID, 0, 0, 0, 0, 0, 0)
+    }
+
+    // only ConfidentialHart or HardwareHart can invoke this function because only they have access to the
+    // HartArchitecturalState storing confidential information
+    pub fn from_hart_state(hart_state: &HartArchitecturalState) -> Self {
         Self::new(
             hart_state.gpr(GpRegister::a7),
             hart_state.gpr(GpRegister::a6),

--- a/security-monitor/src/core/transformations/sbi_result.rs
+++ b/security-monitor/src/core/transformations/sbi_result.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::architecture::{GpRegister, HartState};
+use crate::core::architecture::{GpRegister, HartArchitecturalState};
 
 /// Sbi is a result of the SBI call from the Hypervisor to the SBI
 /// firmware or a result of the SBI call to the security monitor.
@@ -19,7 +19,7 @@ impl SbiResult {
         Self { a0, a1, pc_offset }
     }
 
-    pub fn ecall(hart_state: &HartState) -> Self {
+    pub fn ecall(hart_state: &HartArchitecturalState) -> Self {
         Self::new(hart_state.gpr(GpRegister::a0), hart_state.gpr(GpRegister::a1), Self::ECALL_INSTRUCTION_LENGTH)
     }
 

--- a/security-monitor/src/core/transformations/sbi_vm_request.rs
+++ b/security-monitor/src/core/transformations/sbi_vm_request.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::architecture::{GpRegister, HartState};
+use crate::core::architecture::{GpRegister, HartArchitecturalState};
 use crate::core::transformations::SbiRequest;
 
 pub struct SbiVmRequest {
@@ -10,7 +10,7 @@ pub struct SbiVmRequest {
 }
 
 impl SbiVmRequest {
-    pub fn from_hart_state(hart_state: &HartState) -> Self {
+    pub fn from_hart_state(hart_state: &HartArchitecturalState) -> Self {
         let sbi_request = SbiRequest::new(
             hart_state.gpr(GpRegister::a7),
             hart_state.gpr(GpRegister::a6),

--- a/security-monitor/src/error.rs
+++ b/security-monitor/src/error.rs
@@ -51,7 +51,7 @@ pub enum Error {
     #[error("Invalid confidential VM ID")]
     InvalidConfidentialVmId(),
     #[error("vHart is running")]
-    RunningVHart(),
+    HartAlreadyRunning(),
     #[error("Invalid riscv instruction: {0:x}")]
     InvalidRiscvInstruction(usize),
     #[error("Not supported interrupt")]
@@ -64,6 +64,16 @@ pub enum Error {
     ReachedMaxNumberOfRemoteHartRequests(),
     #[error("Sending interrupt error")]
     InterruptSendingError(),
+
+    // SBI HSM extension related errors
+    #[error("Cannot start a confidential hart because it is not in the Stopped state.")]
+    CannotStartNotStoppedHart(),
+    #[error("Cannot stop a confidential hart because it is not in the Started state.")]
+    CannotStopNotStartedHart(),
+    #[error("Cannot suspend a confidential hart because it is not in the Started state.")]
+    CannotSuspedNotStartedHart(),
+    #[error("Cannot start a confidential hart because it is not in the Suspended state.")]
+    CannotStartNotSuspendedHart(),
 }
 
 impl Error {

--- a/security-monitor/src/non_confidential_flow/handlers/terminate.rs
+++ b/security-monitor/src/non_confidential_flow/handlers/terminate.rs
@@ -1,16 +1,14 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::control_data::{ConfidentialVmId, ControlData};
+use crate::core::control_data::ControlData;
 use crate::core::transformations::{ExposeToHypervisor, SbiResult, TerminateRequest};
-use crate::error::Error;
 use crate::non_confidential_flow::NonConfidentialFlow;
 
 /// The hypervisor command to terminate the confidential VM and remove it from the memory.
 pub fn handle(terminate_request: TerminateRequest, non_confidential_flow: NonConfidentialFlow) -> ! {
     let transformation = ControlData::try_write(|control_data| {
         let confidential_vm_id = terminate_request.confidential_vm_id();
-        ensure_that_the_confidential_vm_can_be_terminated(control_data, confidential_vm_id)?;
         debug!("Terminating the confidential VM[id={:?}]", confidential_vm_id);
         control_data.remove_confidential_vm(confidential_vm_id)
     })
@@ -18,12 +16,4 @@ pub fn handle(terminate_request: TerminateRequest, non_confidential_flow: NonCon
     .unwrap_or_else(|error| error.into_non_confidential_transformation());
 
     non_confidential_flow.exit_to_hypervisor(transformation)
-}
-
-fn ensure_that_the_confidential_vm_can_be_terminated(
-    control_data: &ControlData, confidential_vm_id: ConfidentialVmId,
-) -> Result<(), Error> {
-    let confidential_vm = control_data.confidential_vm(confidential_vm_id)?;
-    assure_not!(confidential_vm.is_running(), Error::RunningVHart())?;
-    Ok(())
 }


### PR DESCRIPTION
This PR introduces support for the SBI HSM extensions. What is missing, but will be added as future PRs, is the proper error handling, including use of SBI error codes, and moving out of the suspended state in a response to an interrupt or hardware event.