### PR TITLE
Parsing FDT during promotion of a VM to a confidential VM

### DIFF
--- a/confidential-vms/linux_vm/patches/linux/6.3-rc5/ace.patch
+++ b/confidential-vms/linux_vm/patches/linux/6.3-rc5/ace.patch
@@ -95,7 +95,7 @@ index 000000000000..1244d0fd59e4
 +#endif /* _ASM_RISCV_ACE_MEM_ENCRYPT_H */
 \ No newline at end of file
 diff --git a/arch/riscv/kernel/setup.c b/arch/riscv/kernel/setup.c
-index 376d2827e736..82cfa818d859 100644
+index 376d2827e736..df44b0c71ad6 100644
 --- a/arch/riscv/kernel/setup.c
 +++ b/arch/riscv/kernel/setup.c
 @@ -20,7 +20,7 @@
@@ -116,7 +116,7 @@ index 376d2827e736..82cfa818d859 100644
 +	// TODO: read the total memory size and expose it to the hypervisor with the call
 +	sbi_ecall(0x509999, 0, 0, 0, 0, 0, 0, 0);
 +	// Request the security monitor to promote the VM to a confidential VM
-+	sbi_ecall(0x510000, 1000, 0, 0, 0, 0, 0, 0);
++	sbi_ecall(0x510000, 1000, _dtb_early_pa, 0, 0, 0, 0, 0);
 +	// END ACE INIT
 +
  	early_ioremap_setup();

--- a/security-monitor/Cargo.toml
+++ b/security-monitor/Cargo.toml
@@ -6,26 +6,26 @@ description = "Assured Confidential Execution (ACE): security monitor implementa
 edition = "2021"
 
 [dependencies]
-# This crate decodes RISC-V instructions unfortunately it does not support the C-instructions yet
-riscv-decode = "0.2" 
+# Below crate provides a parser of flattened device tree (FDT) data. It is used in the initialization procedure
+# and when promoting a VM to a confidential VM.
+flattened_device_tree = {path = "rust-crates/flattened_device_tree"}
 
-# The `fdt` crate provides a parser of flattened device tree (FDT) data. Used in the initialization procedure
-# and when converting a VM into a confidential VM.
-fdt = "0.1.5"
+# Memoffset automatize calculating offsets to internal fields of Rust structures. These offsets are used then by 
+# assembly code in the context switch implementation.
+memoffset = { version = "0.9", default-features = false, features = ["unstable_const"] }
 
 # Rust bindings to OpenSBI C code.
 opensbi-sys = {path = "rust-crates/opensbi-sys"}
-
-# The `spin` crate provides synchronization primitives (Mutexes etc) using spinlocks
-spin = {version="0.9", default-features = false, features = ["once", "rwlock", "spin_mutex"]}
 
 # This is our custom utility library to work with raw pointers. We might get rid of it in future, once there is
 # an equivalent for it in the standard Rust library
 pointers_utility = {path = "rust-crates/pointers_utility"}
 
-# Memoffset automatize calculating offsets to internal fields of Rust structures. These offsets are used then by 
-# assembly code in the context switch implementation.
-memoffset = { version = "0.9", default-features = false, features = ["unstable_const"] }
+# This crate decodes RISC-V instructions unfortunately it does not support the C-instructions yet
+riscv-decode = "0.2" 
+
+# The `spin` crate provides synchronization primitives (Mutexes etc) using spinlocks
+spin = {version="0.9", default-features = false, features = ["once", "rwlock", "spin_mutex"]}
 
 # provides macros that help removing boilerplate code in the rust error handling
 thiserror-no-std = "2.0" 

--- a/security-monitor/rust-crates/flattened_device_tree/Cargo.toml
+++ b/security-monitor/rust-crates/flattened_device_tree/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "flattened_device_tree"
+version = "0.1.0"
+authors = ["Wojciech Ozga <woz@zurich.ibm.com>"]
+description = "Wrapper over existing FDT to narrow the interface for easier switching among FDT implementations"
+edition = "2021"
+
+[dependencies]
+# The `fdt` crate provides a parser of flattened device tree (FDT) data. Used in the initialization procedure
+# and when converting a VM into a confidential VM.
+fdt = { version = "0.1.5", default-features = false, features = [] }
+
+# we must got rid of the above `fdt` dependency because of its quality, although the API was much nicer. 
+# Instead let's rely for now on `fdt-rs` crate for parsing the flattened device tree (FDT).
+fdt-rs = { version = "0.4", default-features = false, features = [] }
+
+# provides macros that help removing boilerplate code in rust error handling
+thiserror-no-std = "2.0" 

--- a/security-monitor/rust-crates/flattened_device_tree/Cargo.toml
+++ b/security-monitor/rust-crates/flattened_device_tree/Cargo.toml
@@ -6,12 +6,6 @@ description = "Wrapper over existing FDT to narrow the interface for easier swit
 edition = "2021"
 
 [dependencies]
-# The `fdt` crate provides a parser of flattened device tree (FDT) data. Used in the initialization procedure
-# and when converting a VM into a confidential VM.
-fdt = { version = "0.1.5", default-features = false, features = [] }
-
-# we must got rid of the above `fdt` dependency because of its quality, although the API was much nicer. 
-# Instead let's rely for now on `fdt-rs` crate for parsing the flattened device tree (FDT).
 fdt-rs = { version = "0.4", default-features = false, features = [] }
 
 # provides macros that help removing boilerplate code in rust error handling

--- a/security-monitor/rust-crates/flattened_device_tree/src/error.rs
+++ b/security-monitor/rust-crates/flattened_device_tree/src/error.rs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2023 IBM Corporation
+// SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
+// SPDX-License-Identifier: Apache-2.0
+use thiserror_no_std::Error;
+use fdt_rs::error::DevTreeError;
+
+#[derive(Error, Debug)]
+pub enum FdtError {
+    #[error("FDT pointer not aligned")]
+    FdtPointerNotAligned(),
+    #[error("FDT error: {0}")]
+    FdtErrorParsing(#[from] DevTreeError),
+    #[error("No memory node")]
+    NoMemoryNode(),
+}

--- a/security-monitor/rust-crates/flattened_device_tree/src/lib.rs
+++ b/security-monitor/rust-crates/flattened_device_tree/src/lib.rs
@@ -20,7 +20,7 @@ pub struct FlattenedDeviceTree<'a> {
 }
 
 impl<'a> FlattenedDeviceTree<'a> {
-    /// Creates an instance of a wrapper over the library that parses the flattened device tree (FDT). Returns error if address is not a 32-bytes aligned pointer to the valid flattened device tree (FDT).
+    /// Creates an instance of a wrapper over the library that parses the flattened device tree (FDT). Returns error if address is not a 4-bytes aligned pointer to the valid flattened device tree (FDT).
     ///
     /// # Safety
     ///

--- a/security-monitor/rust-crates/flattened_device_tree/src/lib.rs
+++ b/security-monitor/rust-crates/flattened_device_tree/src/lib.rs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2023 IBM Corporation
+// SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
+// SPDX-License-Identifier: Apache-2.0
+#![no_std]
+#![no_main]
+
+use fdt_rs::base::DevTree;
+use fdt_rs::prelude::{FallibleIterator, PropReader};
+use fdt_rs::base::DevTreeNode;
+use crate::FdtError::FdtPointerNotAligned;
+use core::mem::align_of;
+
+pub use crate::error::FdtError;
+
+mod error;
+
+/// This is a wrapper over a third party library that parses the flattened device tree (FDT).
+pub struct FlattenedDeviceTree<'a> {
+    inner: DevTree<'a>
+}
+
+impl<'a> FlattenedDeviceTree<'a> {
+    /// Creates an instance of a wrapper over the library that parses the flattened device tree (FDT). Returns error if address is not a 32-bytes aligned pointer to the valid flattened device tree (FDT).
+    ///
+    /// # Safety
+    ///
+    /// Caller must guarantee that:
+    ///   * the length of the pointed buffer is at least `DevTree::MIN_HEADER_SIZE`
+    pub unsafe fn from_raw_pointer(address: *const u8) -> Result<Self, FdtError> {
+        if address.align_offset(align_of::<u32>()) != 0 {
+            return Err(FdtPointerNotAligned());
+        }
+        Ok(Self { inner: unsafe { DevTree::from_raw_pointer(address)? } })
+    }
+
+    pub fn harts<'b>(&'b self) -> impl Iterator<Item = Hart<'b, 'a>> {
+        self.inner
+            .nodes()
+            .filter(|n| {
+                n.props()
+                    .any(|p| Ok(p.name()? == "device_type" && p.str()? == "cpu"))
+            })
+            .iterator()
+            .filter_map(|n| Some(Hart { inner: n.ok()? }))
+    }
+
+    pub fn memory(&self) -> Result<FdtMemoryRegion, FdtError>  {
+        let mem_prop = self.inner.props()
+            .find(|p| Ok(p.name()? == "device_type" && p.str()? == "memory"))?
+            .ok_or_else(|| FdtError::NoMemoryNode())?;
+
+        let reg_prop = mem_prop.node()
+            .props()
+            .find(|p| Ok(p.name().unwrap_or("empty") == "reg"))?
+            .ok_or_else(|| FdtError::NoMemoryNode())?;
+
+        Ok(FdtMemoryRegion { base: reg_prop.u64(0)?, size: reg_prop.u64(1)? })
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct FdtMemoryRegion {
+    pub base: u64,
+    pub size: u64,
+}
+
+#[derive(Clone)]
+pub struct Hart<'a, 'dt> {
+    inner: DevTreeNode<'a, 'dt>,
+}
+
+impl<'a, 'dt> Hart<'a, 'dt> {
+    pub fn hart_id(&self) -> Option<u64> {
+        let prop = self.inner.props().find(|p| Ok(p.name()? == "reg")).ok()??;
+        Some(prop.u32(0).ok()? as u64)
+    }
+
+    pub fn property_str(&self, name: &str) -> Option<&str> {
+        let prop = self.inner.props().find(|p| Ok(p.name()? == name)).ok()??;
+        let value = core::str::from_utf8(prop.propbuf()).ok().and_then(|v| v.strip_suffix('\0'))?;
+        Some(value)
+    }
+
+}

--- a/security-monitor/src/core/control_data/confidential_hart.rs
+++ b/security-monitor/src/core/control_data/confidential_hart.rs
@@ -399,6 +399,7 @@ impl ConfidentialHart {
         let is_mprv_set = is_bit_enabled(CSR.mstatus.read(), CSR_MSTATUS_MPRV);
         CSR.mstatus.read_and_set_bit(CSR_MSTATUS_MPRV);
         let instruction = unsafe {
+            // TODO: use `minst` register if available
             let instruction = fault_instruction_virtual_address.read_volatile();
             instruction
         };

--- a/security-monitor/src/core/control_data/confidential_vm.rs
+++ b/security-monitor/src/core/control_data/confidential_vm.rs
@@ -24,6 +24,7 @@ impl ConfidentialVm {
     const AVG_NUMBER_OF_REMOTE_HART_REQUESTS: usize = 3;
     /// A maximum number of inter hart requests that can be buffered.
     const MAX_NUMBER_OF_REMOTE_HART_REQUESTS: usize = 64;
+    pub const MAX_NUMBER_OF_HARTS_PER_VM: usize = 1024;
 
     /// Constructs a new confidential VM.
     ///

--- a/security-monitor/src/core/memory_layout/confidential_memory_address.rs
+++ b/security-monitor/src/core/memory_layout/confidential_memory_address.rs
@@ -21,6 +21,10 @@ impl ConfidentialMemoryAddress {
         self.0
     }
 
+    pub unsafe fn to_ptr(&self) -> *const u8 {
+        self.0 as *const u8
+    }
+
     pub fn as_usize(&self) -> usize {
         self.0 as usize
     }

--- a/security-monitor/src/core/memory_layout/confidential_vm_physical_address.rs
+++ b/security-monitor/src/core/memory_layout/confidential_vm_physical_address.rs
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[derive(PartialEq, Clone, Copy)]
-pub struct ConfidentialVmVirtualAddress(usize);
+pub struct ConfidentialVmPhysicalAddress(usize);
 
-impl ConfidentialVmVirtualAddress {
-    pub fn new(address: usize) -> Self {
-        Self(address)
+impl ConfidentialVmPhysicalAddress {
+    pub fn new(confidential_vm_physical_address: usize) -> Self {
+        Self(confidential_vm_physical_address)
     }
 
     pub fn usize(&self) -> usize {
@@ -15,8 +15,8 @@ impl ConfidentialVmVirtualAddress {
     }
 }
 
-impl core::fmt::Debug for ConfidentialVmVirtualAddress {
+impl core::fmt::Debug for ConfidentialVmPhysicalAddress {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "confidential_vm_virtual_address={:x}", self.0)
+        write!(f, "Confidential VM physical address={:x}", self.0)
     }
 }

--- a/security-monitor/src/core/memory_layout/mod.rs
+++ b/security-monitor/src/core/memory_layout/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
 pub use confidential_memory_address::ConfidentialMemoryAddress;
-pub use confidential_vm_virtual_address::ConfidentialVmVirtualAddress;
+pub use confidential_vm_physical_address::ConfidentialVmPhysicalAddress;
 pub use non_confidential_memory_address::NonConfidentialMemoryAddress;
 
 use crate::core::memory_protector::PageSize;
@@ -11,7 +11,7 @@ use pointers_utility::{ptr_align, ptr_byte_add_mut, ptr_byte_offset};
 use spin::Once;
 
 mod confidential_memory_address;
-mod confidential_vm_virtual_address;
+mod confidential_vm_physical_address;
 mod non_confidential_memory_address;
 
 const NOT_INITIALIZED_MEMORY_LAYOUT: &str = "Bug. Could not access MemoryLayout because is has not been initialized";

--- a/security-monitor/src/core/memory_protector/mmu/page_table.rs
+++ b/security-monitor/src/core/memory_protector/mmu/page_table.rs
@@ -155,7 +155,7 @@ impl PageTable {
         panic!("Unimplemented");
     }
 
-    /// Translates the guest physical address to host physical address by doing a page walk. Error is returns if there exists no mapping for
+    /// Translates the guest physical address to host physical address by doing a page walk. Error is returned if there exists no mapping for
     /// the requested guest physical address or the address translates to a shared page.
     ///
     /// This is a recursive function, which deepest execution is not larger than the number of paging system levels.

--- a/security-monitor/src/core/memory_protector/mmu/paging_system.rs
+++ b/security-monitor/src/core/memory_protector/mmu/paging_system.rs
@@ -2,7 +2,7 @@
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
 use crate::core::architecture::HgatpMode;
-use crate::core::memory_layout::ConfidentialVmVirtualAddress;
+use crate::core::memory_layout::ConfidentialVmPhysicalAddress;
 use crate::core::memory_protector::PageSize;
 
 // TODO: add more 2nd-level paging systems corresponding to 3 and 4 level page
@@ -58,7 +58,7 @@ impl PagingSystem {
         }
     }
 
-    pub fn vpn(&self, virtual_address: ConfidentialVmVirtualAddress, level: PageTableLevel) -> usize {
+    pub fn vpn(&self, virtual_address: ConfidentialVmPhysicalAddress, level: PageTableLevel) -> usize {
         match self {
             PagingSystem::Sv57x4 => match level {
                 PageTableLevel::Level5 => (virtual_address.usize() >> 48) & 0x3ff,

--- a/security-monitor/src/core/page_allocator/page.rs
+++ b/security-monitor/src/core/page_allocator/page.rs
@@ -94,6 +94,10 @@ impl Page<Allocated> {
 }
 
 impl<T: PageState> Page<T> {
+    pub fn address(&self) -> &ConfidentialMemoryAddress {
+        &self.address
+    }
+
     pub fn start_address(&self) -> usize {
         self.address.as_usize()
     }

--- a/security-monitor/src/core/page_allocator/shared_page.rs
+++ b/security-monitor/src/core/page_allocator/shared_page.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::memory_layout::{ConfidentialVmVirtualAddress, MemoryLayout, NonConfidentialMemoryAddress};
+use crate::core::memory_layout::{ConfidentialVmPhysicalAddress, MemoryLayout, NonConfidentialMemoryAddress};
 use crate::core::memory_protector::PageSize;
 use crate::core::transformations::SharePageRequest;
 use crate::error::Error;
@@ -14,7 +14,7 @@ use crate::error::Error;
 /// hardware ensures synchronized access to these memory locations.
 pub struct SharedPage {
     hypervisor_address: NonConfidentialMemoryAddress,
-    confidential_vm_virtual_address: ConfidentialVmVirtualAddress,
+    confidential_vm_virtual_address: ConfidentialVmPhysicalAddress,
     page_size: PageSize,
 }
 
@@ -41,7 +41,7 @@ impl SharedPage {
         self.hypervisor_address.usize()
     }
 
-    pub fn confidential_vm_virtual_address(&self) -> ConfidentialVmVirtualAddress {
+    pub fn confidential_vm_virtual_address(&self) -> ConfidentialVmPhysicalAddress {
         self.confidential_vm_virtual_address
     }
 }

--- a/security-monitor/src/core/transformations/promote_to_confidential_vm_request.rs
+++ b/security-monitor/src/core/transformations/promote_to_confidential_vm_request.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::architecture::HartArchitecturalState;
+use crate::core::architecture::{GeneralPurposeRegister, HartArchitecturalState};
+use crate::core::memory_layout::ConfidentialVmPhysicalAddress;
 
 pub struct PromoteToConfidentialVm {
     hart_state: HartArchitecturalState,
@@ -13,7 +14,12 @@ impl PromoteToConfidentialVm {
         Self { hart_state }
     }
 
-    pub fn into(self) -> HartArchitecturalState {
-        self.hart_state
+    /// Returns the address of the device tree provided as the first argument of the call.
+    pub fn fdt_address(&self) -> ConfidentialVmPhysicalAddress {
+        ConfidentialVmPhysicalAddress::new(self.hart_state.gpr(GeneralPurposeRegister::a0))
+    }
+
+    pub fn into(self) -> (ConfidentialVmPhysicalAddress, HartArchitecturalState) {
+        (self.fdt_address(), self.hart_state)
     }
 }

--- a/security-monitor/src/core/transformations/share_page_request.rs
+++ b/security-monitor/src/core/transformations/share_page_request.rs
@@ -1,23 +1,23 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::memory_layout::ConfidentialVmVirtualAddress;
+use crate::core::memory_layout::ConfidentialVmPhysicalAddress;
 use crate::core::memory_protector::PageSize;
 use crate::error::Error;
 
 #[derive(PartialEq)]
 pub struct SharePageRequest {
-    confidential_vm_virtual_address: ConfidentialVmVirtualAddress,
+    confidential_vm_virtual_address: ConfidentialVmPhysicalAddress,
     page_size: PageSize,
 }
 
 impl SharePageRequest {
     pub fn new(address: usize) -> Result<Self, Error> {
-        let confidential_vm_virtual_address = ConfidentialVmVirtualAddress::new(address);
+        let confidential_vm_virtual_address = ConfidentialVmPhysicalAddress::new(address);
         Ok(Self { confidential_vm_virtual_address, page_size: PageSize::Size4KiB })
     }
 
-    pub fn confidential_vm_virtual_address(&self) -> ConfidentialVmVirtualAddress {
+    pub fn confidential_vm_virtual_address(&self) -> ConfidentialVmPhysicalAddress {
         self.confidential_vm_virtual_address
     }
 

--- a/security-monitor/src/core/transformations/unshare_page_request.rs
+++ b/security-monitor/src/core/transformations/unshare_page_request.rs
@@ -1,21 +1,21 @@
 // SPDX-FileCopyrightText: 2023 IBM Corporation
 // SPDX-FileContributor: Wojciech Ozga <woz@zurich.ibm.com>, IBM Research - Zurich
 // SPDX-License-Identifier: Apache-2.0
-use crate::core::memory_layout::ConfidentialVmVirtualAddress;
+use crate::core::memory_layout::ConfidentialVmPhysicalAddress;
 use crate::error::Error;
 
 #[derive(PartialEq)]
 pub struct UnsharePageRequest {
-    confidential_vm_virtual_address: ConfidentialVmVirtualAddress,
+    confidential_vm_virtual_address: ConfidentialVmPhysicalAddress,
 }
 
 impl UnsharePageRequest {
     pub fn new(address: usize) -> Result<Self, Error> {
-        let confidential_vm_virtual_address = ConfidentialVmVirtualAddress::new(address);
+        let confidential_vm_virtual_address = ConfidentialVmPhysicalAddress::new(address);
         Ok(Self { confidential_vm_virtual_address })
     }
 
-    pub fn confidential_vm_virtual_address(&self) -> ConfidentialVmVirtualAddress {
+    pub fn confidential_vm_virtual_address(&self) -> ConfidentialVmPhysicalAddress {
         self.confidential_vm_virtual_address
     }
 }

--- a/security-monitor/src/error.rs
+++ b/security-monitor/src/error.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::core::transformations::{ExposeToConfidentialVm, ExposeToHypervisor, SbiResult};
 use core::num::TryFromIntError;
-use fdt::FdtError;
 use pointers_utility::PointerError;
 use thiserror_no_std::Error;
 
@@ -24,8 +23,6 @@ pub enum Error {
     Reinitialization(),
     #[error("Not supported hardware")]
     NotSupportedHardware(HardwareFeatures),
-    #[error("FDT read error")]
-    FdtFromPtr(#[from] FdtError),
     #[error("Error while searching FDT for a property")]
     FdtParsing(),
     #[error("Could not convert SBI argument to usize: {0}")]

--- a/security-monitor/src/error.rs
+++ b/security-monitor/src/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     OutOfPages(),
     #[error("Page table error")]
     PageTableConfiguration(),
+    #[error("Address translation failed")]
+    AddressTranslationFailed(),
     #[error("Page Table is corrupted")]
     PageTableCorrupted(),
     #[error("Reached a maximum number of confidential VMs")]
@@ -48,6 +50,8 @@ pub enum Error {
     PendingRequest(),
     #[error("Invalid Hart ID")]
     InvalidHartId(),
+    #[error("Exceeded the max number of harts per VM")]
+    ReachedMaxNumberOfHartsPerVm(),
     #[error("Invalid confidential VM ID")]
     InvalidConfidentialVmId(),
     #[error("vHart is running")]
@@ -73,6 +77,8 @@ pub enum Error {
     CannotSuspedNotStartedHart(),
     #[error("Cannot start a confidential hart because it is not in the Suspended state.")]
     CannotStartNotSuspendedHart(),
+    #[error("Device Tree Error")]
+    DeviceTreeError(#[from] flattened_device_tree::FdtError),
 }
 
 impl Error {
@@ -89,8 +95,6 @@ impl Error {
 
 #[derive(Error, Debug)]
 pub enum InitType {
-    #[error("FDT's memory node not found")]
-    FdtMemory,
     #[error("Too little memory")]
     NotEnoughMemory,
     #[error("Invalid memory boundaries")]

--- a/security-monitor/src/non_confidential_flow/handlers/promote_to_confidential_vm.rs
+++ b/security-monitor/src/non_confidential_flow/handlers/promote_to_confidential_vm.rs
@@ -6,44 +6,76 @@ use crate::core::memory_protector::ConfidentialVmMemoryProtector;
 use crate::core::transformations::{ExposeToHypervisor, PromoteToConfidentialVm, SbiRequest};
 use crate::error::Error;
 use crate::non_confidential_flow::NonConfidentialFlow;
+use flattened_device_tree::FlattenedDeviceTree;
 
+/// Our convention is to give the boot hart a fixed id.
 const BOOT_HART_ID: usize = 0;
 
-/// Handles the `promote to confidential VM` call requested by the non-confidential VM via `ecall`. The call traps in the security monitor
-/// as an `environment call from VS-mode` (see `mcause` register specification). In a response to this call, the security monitor creates a
-/// confidential VM and informs the hypervisor that the VM became a confidential VM. The hypervisor should then record this information and
-/// use dedicated entry point (`resume confidential hart` call) to execute particular confidential hart.
+/// Handles the `promote to confidential VM` call requested by the non-confidential VM via an environment call. The call traps in the
+/// security monitor as an `environment call from VS-mode` (see `mcause` register specification). In a response to this call, the security
+/// monitor creates a confidential VM and informs the hypervisor that the VM became a confidential VM. The hypervisor should then record
+/// this information and use dedicated entry point (`resume confidential hart` call) to execute particular confidential hart.
 ///
-/// Security constrain: In case of a Linux kernel confidential VM, Linux kernel must make this call before it uses parameters from the Linux
-/// command line and before it changes the content of the VM's memory.
+/// # Security
+///
+/// In case of a Linux kernel confidential VM, Linux kernel must make this call before 1) it uses parameters from the Linux command line, 2)
+/// before it changes the content of the VM's memory.
+///
+/// # Safety
+///
+/// The virtual machine must make this call on a boot hart before other harts come out of reset.
 pub fn handle(promote_to_confidential_vm_request: PromoteToConfidentialVm, non_confidential_flow: NonConfidentialFlow) -> ! {
     debug!("Promoting a VM into a confidential VM");
     let transformation = match create_confidential_vm(promote_to_confidential_vm_request) {
         Ok(id) => ExposeToHypervisor::SbiRequest(SbiRequest::kvm_ace_register(id, BOOT_HART_ID)),
-        Err(error) => error.into_non_confidential_transformation(),
+        Err(error) => {
+            debug!("Promotion to confidential VM failed: {:?}", error);
+            error.into_non_confidential_transformation()
+        }
     };
     non_confidential_flow.exit_to_hypervisor(transformation)
 }
 
 fn create_confidential_vm(promote_to_confidential_vm_request: PromoteToConfidentialVm) -> Result<ConfidentialVmId, Error> {
-    let hart_state = promote_to_confidential_vm_request.into();
+    // The pointer to the flattened device tree (FDT) as well as the entire FDT must be treated as an untrusted input, which measurement is
+    // reflected during attestation. Only after moving VM's data (and the FDT) to the confidential memory, we can check if the pointer is
+    // valid, i.e., it points to a valid address in the confidential VM's address space.
+    //
+    // We use only the hart state of the currently executing hart, i.e., the hart that triggered the `promote to confidential VM call`. All
+    // other harts are assumed to be in the reset state (safety requirement).
+    let (fdt_address, hart_state) = promote_to_confidential_vm_request.into();
 
+    // Copy the entire VM's state to the confidential memory, recreating the MMU configuration.
     let memory_protector = ConfidentialVmMemoryProtector::from_vm_state(&hart_state)?;
-    // TODO: read number of harts from fdt
-    let confidential_harts_count = 2;
-    let confidential_harts = (0..confidential_harts_count)
+
+    // Below use of unsafe is ok because (1) the security monitor owns the memory region containing the data of the not-yet-created
+    // confidential VM's and (2) there is only one physical hart executing this code.
+    let fdt_address_in_confidential_memory = unsafe { memory_protector.translate(fdt_address)?.to_ptr() };
+    // We parse untrusted FDT using an external library. A vulnerability in this library might blow up the security!
+    // Below unsafe is ok because it is the start of the entire page which is at least 4KiB in size (see safety requirements of
+    // `FlattenedDeviceTree::from_raw_pointer`).
+    let device_tree = unsafe { FlattenedDeviceTree::from_raw_pointer(fdt_address_in_confidential_memory)? };
+
+    // We create a fixed number of harts (all but the boot hart are in the reset state) according to the FDT configuration. An alternative
+    // approach (to discuss) is to create just a boot hart and then allow creation of more harts when getting a call from the confidential
+    // VM to start a hart.
+    let number_of_confidential_harts = device_tree.harts().count();
+    assure!(number_of_confidential_harts < ConfidentialVm::MAX_NUMBER_OF_HARTS_PER_VM, Error::ReachedMaxNumberOfHartsPerVm())?;
+    let confidential_harts = (0..number_of_confidential_harts)
         .map(|confidential_hart_id| match confidential_hart_id {
             0 => ConfidentialHart::from_vm_hart(confidential_hart_id, &hart_state),
             _ => ConfidentialHart::from_vm_hart_reset(confidential_hart_id, &hart_state),
         })
         .collect();
+
     // TODO: measure the confidential VM
-    // TODO: perform local attestation (optional)
     let measurements = [ConfidentialVmMeasurement::empty(); 4];
+
+    // TODO: perform local attestation (optional) if there is a `confidential VM's blob`
 
     let confidential_vm_id = ControlData::try_write(|control_data| {
         // We have a write lock on the entire control data! Spend as little time here as possible because we are
-        // blocking all other harts from accessing the control data.
+        // blocking all other harts from accessing the control data. This influences all confidential VMs in the system!
         let id = control_data.unique_id()?;
         let confidential_vm = ConfidentialVm::new(id, confidential_harts, measurements, memory_protector);
         control_data.insert_confidential_vm(confidential_vm)


### PR DESCRIPTION
This PR adds parsing of FDT when promoting VM to confidential VM. As part of this PR we get rid of the dependency to `fdt`  crate in favor of `fdt-rs`. Since none of existing rust `fdt` crates are of good enough quality, we hide the currently used `fdt-rs` dependency behind a custom proxy `flattened_device_tree`.

After the initial evaluation, this PR should receive additional commits that parse more information from the VM's FDT.