### PR TITLE
Adding FDT relocation and initial skeleton for local attestation

### DIFF
--- a/security-monitor/src/core/memory_layout/confidential_vm_physical_address.rs
+++ b/security-monitor/src/core/memory_layout/confidential_vm_physical_address.rs
@@ -10,6 +10,10 @@ impl ConfidentialVmPhysicalAddress {
         Self(confidential_vm_physical_address)
     }
 
+    pub fn add(&self, offset: usize) -> Self {
+        Self(self.0 + offset)
+    }
+
     pub fn usize(&self) -> usize {
         self.0
     }

--- a/security-monitor/src/core/memory_protector/confidential_vm_memory_protector.rs
+++ b/security-monitor/src/core/memory_protector/confidential_vm_memory_protector.rs
@@ -61,7 +61,7 @@ impl ConfidentialVmMemoryProtector {
 
     /// Translates guest physical address into a real physical address in the confidential memory. Returns error if the guest physical
     /// address is not mapped into the real physical address, i.e., page table walk fails.
-    pub fn translate_address(&self, address: &ConfidentialVmPhysicalAddress) -> Result<&ConfidentialMemoryAddress, Error> {
+    pub fn translate_address(&self, address: &ConfidentialVmPhysicalAddress) -> Result<ConfidentialMemoryAddress, Error> {
         self.root_page_table.translate(address)
     }
 

--- a/security-monitor/src/core/memory_protector/mmu/page_table.rs
+++ b/security-monitor/src/core/memory_protector/mmu/page_table.rs
@@ -36,7 +36,7 @@ impl RootPageTable {
         self.page_table.unmap_shared_page(self.paging_system, address)
     }
 
-    pub fn translate(&self, address: &ConfidentialVmPhysicalAddress) -> Result<&ConfidentialMemoryAddress, Error> {
+    pub fn translate(&self, address: &ConfidentialVmPhysicalAddress) -> Result<ConfidentialMemoryAddress, Error> {
         self.page_table.translate(self.paging_system, address)
     }
 
@@ -193,11 +193,16 @@ impl PageTable {
     /// This is a recursive function, which deepest execution is not larger than the number of paging system levels.
     pub fn translate(
         &self, paging_system: PagingSystem, address: &ConfidentialVmPhysicalAddress,
-    ) -> Result<&ConfidentialMemoryAddress, Error> {
+    ) -> Result<ConfidentialMemoryAddress, Error> {
         let virtual_page_number = paging_system.vpn(address, self.level);
         match self.entries.get(virtual_page_number).ok_or_else(|| Error::PageTableConfiguration())? {
             PageTableEntry::PointerToNextPageTable(next_page_table, _) => next_page_table.translate(paging_system, address),
-            PageTableEntry::PageWithConfidentialVmData(page, _configuration, _permission) => Ok(page.address()),
+            PageTableEntry::PageWithConfidentialVmData(page, _configuration, _permission) => {
+                let page_offset = paging_system.page_offset(address, self.level);
+                // below unsafe is ok because page_offset recorded in the page table entry is lower than the page size. Thus, we the
+                // resulting address will still be in confidential memory because the page is in confidential memory by definition.
+                Ok(unsafe { page.address().add(page_offset, page.end_address_ptr())? })
+            }
             _ => Err(Error::AddressTranslationFailed()),
         }
     }

--- a/security-monitor/src/core/memory_protector/mmu/paging_system.rs
+++ b/security-monitor/src/core/memory_protector/mmu/paging_system.rs
@@ -71,6 +71,21 @@ impl PagingSystem {
         }
     }
 
+    pub fn page_offset(&self, virtual_address: &ConfidentialVmPhysicalAddress, level: PageTableLevel) -> usize {
+        let vpn_bits_mask = match self {
+            PagingSystem::Sv57x4 => match level {
+                PageTableLevel::Level5 => 0xfffffffff << 12,
+                PageTableLevel::Level4 => 0x7ffffff << 12,
+                PageTableLevel::Level3 => 0x3ffff << 12,
+                PageTableLevel::Level2 => 0x1ff << 12,
+                PageTableLevel::Level1 => 0 << 12,
+            },
+        };
+        let vpn_to_rewrite = virtual_address.usize() & vpn_bits_mask;
+        let page_offset = virtual_address.usize() & 0xfff;
+        vpn_to_rewrite | page_offset
+    }
+
     pub fn page_size(&self, level: PageTableLevel) -> PageSize {
         match level {
             PageTableLevel::Level5 => PageSize::Size128TiB,

--- a/security-monitor/src/core/page_allocator/page.rs
+++ b/security-monitor/src/core/page_allocator/page.rs
@@ -157,7 +157,7 @@ impl<T: PageState> Page<T> {
         (0..self.size.in_bytes()).step_by(mem::size_of::<usize>())
     }
 
-    fn end_address_ptr(&self) -> *const usize {
+    pub fn end_address_ptr(&self) -> *const usize {
         self.end_address() as *const usize
     }
 

--- a/security-monitor/src/error.rs
+++ b/security-monitor/src/error.rs
@@ -49,7 +49,7 @@ pub enum Error {
     #[error("Invalid Hart ID")]
     InvalidHartId(),
     #[error("Exceeded the max number of harts per VM")]
-    ReachedMaxNumberOfHartsPerVm(),
+    InvalidNumberOfHartsInFdt(),
     #[error("Invalid confidential VM ID")]
     InvalidConfidentialVmId(),
     #[error("vHart is running")]
@@ -75,6 +75,14 @@ pub enum Error {
     CannotSuspedNotStartedHart(),
     #[error("Cannot start a confidential hart because it is not in the Suspended state.")]
     CannotStartNotSuspendedHart(),
+    #[error("Incorrectly aligned authentication blob")]
+    AuthBlobNotAlignedTo64Bits(),
+    #[error("Authentication blob size is invalid.")]
+    AuthBlobInvalidSize(),
+    #[error("Address not properly aligned")]
+    AddressNotProperlyAligned(),
+    #[error("FDT size is invalid. Expecting at least 40 bytes and maximum 40960 bytes")]
+    FdtInvalidSize(),
     #[error("Device Tree Error")]
     DeviceTreeError(#[from] flattened_device_tree::FdtError),
 }

--- a/security-monitor/src/non_confidential_flow/handlers/promote_vm.rs
+++ b/security-monitor/src/non_confidential_flow/handlers/promote_vm.rs
@@ -7,7 +7,8 @@ use crate::core::control_data::{
     ConfidentialHart, ConfidentialVm, ConfidentialVmId, ConfidentialVmMeasurement, ControlData, HypervisorHart,
 };
 use crate::core::memory_layout::ConfidentialVmPhysicalAddress;
-use crate::core::memory_protector::ConfidentialVmMemoryProtector;
+use crate::core::memory_protector::{ConfidentialVmMemoryProtector, PageSize};
+use crate::core::page_allocator::{Allocated, Page, PageAllocator};
 use crate::error::Error;
 use crate::non_confidential_flow::{ApplyToHypervisor, NonConfidentialFlow};
 use flattened_device_tree::FlattenedDeviceTree;
@@ -28,17 +29,24 @@ const BOOT_HART_ID: usize = 0;
 ///
 /// # Safety
 ///
-/// The virtual machine must make this call on a boot hart before other harts come out of reset.
+/// * The virtual machine must make this call on a boot hart before other harts come out of reset.
+/// * the address of the flattened device tree must be aligned to 8 bytes.
+/// * the address of the authentication blob must be either `0` or aligned to 8 bytes.
 pub struct PromoteVmHandler {
     hart_state: HartArchitecturalState,
     fdt_address: ConfidentialVmPhysicalAddress,
+    auth_blob_address: Option<ConfidentialVmPhysicalAddress>,
 }
 
 impl PromoteVmHandler {
     pub fn from_vm_hart(hypervisor_hart: &HypervisorHart) -> Self {
         let hart_state = HartArchitecturalState::from_existing(0, hypervisor_hart.hypervisor_hart_state());
         let fdt_address = ConfidentialVmPhysicalAddress::new(hart_state.gprs.read(GeneralPurposeRegister::a0));
-        Self { hart_state, fdt_address }
+        let auth_blob_address = match hart_state.gprs.read(GeneralPurposeRegister::a1) {
+            0 => None,
+            address => Some(ConfidentialVmPhysicalAddress::new(address)),
+        };
+        Self { hart_state, fdt_address, auth_blob_address }
     }
 
     pub fn handle(self, non_confidential_flow: NonConfidentialFlow) -> ! {
@@ -57,28 +65,14 @@ impl PromoteVmHandler {
 
     fn create_confidential_vm(&self) -> Result<ConfidentialVmId, Error> {
         debug!("Promoting a VM into a confidential VM");
-        // The pointer to the flattened device tree (FDT) as well as the entire FDT must be treated as an untrusted input, which measurement
-        // is reflected during attestation. Only after moving VM's data (and the FDT) to the confidential memory, we can check if
-        // the pointer is valid, i.e., it points to a valid address in the confidential VM's address space.
-
         // Copy the entire VM's state to the confidential memory, recreating the MMU configuration.
         let memory_protector = ConfidentialVmMemoryProtector::from_vm_state(&self.hart_state)?;
 
-        // Below use of unsafe is ok because (1) the security monitor owns the memory region containing the data of the not-yet-created
-        // confidential VM's and (2) there is only one physical hart executing this code.
-        let fdt_address_in_confidential_memory = unsafe { memory_protector.translate_address(&self.fdt_address)?.to_ptr() };
-        // Security note: We parse untrusted FDT using an external library. A vulnerability in this library might blow up our security
-        // guarantees!
-        //
-        // Below unsafe is ok because it is the start of the entire page which is at least 4KiB in size (see safety requirements of
-        // `FlattenedDeviceTree::from_raw_pointer`).
-        let device_tree = unsafe { FlattenedDeviceTree::from_raw_pointer(fdt_address_in_confidential_memory)? };
+        // The pointer to the flattened device tree (FDT) as well as the entire FDT must be treated as an untrusted input, which measurement
+        // is reflected during attestation. We can parse FDT only after moving VM's data (and the FDT) to the confidential memory.
+        let number_of_confidential_harts = self.process_device_tree(&memory_protector)?;
 
-        // We create a fixed number of harts (all but the boot hart are in the reset state) according to the FDT configuration. An
-        // alternative approach (to discuss) is to create just a boot hart and then allow creation of more harts when getting a call
-        // from the confidential VM to start a hart.
-        let number_of_confidential_harts = device_tree.harts().count();
-        assure!(number_of_confidential_harts < ConfidentialVm::MAX_NUMBER_OF_HARTS_PER_VM, Error::ReachedMaxNumberOfHartsPerVm())?;
+        // We create a fixed number of harts (all but the boot hart are in the reset state).
         let confidential_harts = (0..number_of_confidential_harts)
             .map(|confidential_hart_id| match confidential_hart_id {
                 0 => ConfidentialHart::from_vm_hart(confidential_hart_id, &self.hart_state),
@@ -89,7 +83,7 @@ impl PromoteVmHandler {
         // TODO: measure the confidential VM
         let measurements = [ConfidentialVmMeasurement::empty(); 4];
 
-        // TODO: perform local attestation (optional) if there is a `confidential VM's blob`
+        self.authenticate_and_authorize_vm(&memory_protector, &measurements)?;
 
         ControlData::try_write(|control_data| {
             // We have a write lock on the entire control data! Spend as little time here as possible because we are
@@ -98,5 +92,80 @@ impl PromoteVmHandler {
             let confidential_vm = ConfidentialVm::new(id, confidential_harts, measurements, memory_protector);
             control_data.insert_confidential_vm(confidential_vm)
         })
+    }
+
+    fn process_device_tree(&self, memory_protector: &ConfidentialVmMemoryProtector) -> Result<usize, Error> {
+        let fdt_address_in_confidential_memory = memory_protector.translate_address(&self.fdt_address)?;
+        // Below use of unsafe is ok because (1) the security monitor owns the memory region containing the data of the not-yet-created
+        // confidential VM's and (2) there is only one physical hart executing this code.
+        let fdt_total_size = unsafe { FlattenedDeviceTree::total_size(fdt_address_in_confidential_memory.to_ptr())? };
+        assure!(fdt_total_size >= FlattenedDeviceTree::FDT_HEADER_SIZE, Error::FdtInvalidSize())?;
+
+        // To work with FDT, we must have it as a continous chunk of memory. We accept only FDTs that fit within 2MiB
+        assure!(fdt_total_size.div_ceil(PageSize::Size2MiB.in_bytes()) == 1, Error::FdtInvalidSize())?;
+        let large_page = Self::relocate(memory_protector, &self.fdt_address, fdt_total_size)?;
+
+        // Security note: We parse untrusted FDT using an external library. A vulnerability in this library might blow up our security
+        // guarantees! Below unsafe is ok because FDT address is at least size of the FDT header and all FDT is in a continuous chunk of
+        // memory. See the safety requirements of `FlattenedDeviceTree::from_raw_pointer`.
+        let number_of_confidential_harts = match unsafe { FlattenedDeviceTree::from_raw_pointer(large_page.address().to_ptr()) } {
+            Ok(device_tree) => device_tree.harts().count(),
+            Err(_) => 0,
+        };
+
+        // Clean up, deallocate pages
+        PageAllocator::release_pages(alloc::vec![large_page.deallocate()]);
+
+        assure!(number_of_confidential_harts > 0, Error::InvalidNumberOfHartsInFdt())?;
+        assure!(number_of_confidential_harts < ConfidentialVm::MAX_NUMBER_OF_HARTS_PER_VM, Error::InvalidNumberOfHartsInFdt())?;
+        Ok(number_of_confidential_harts)
+    }
+
+    /// Performs local attestation. It decides if the VM can be promote into a confidential VM and decrypts the attestation secret intended
+    /// for this confidential VM.
+    fn authenticate_and_authorize_vm(
+        &self, memory_protector: &ConfidentialVmMemoryProtector, _measurements: &[ConfidentialVmMeasurement; 4],
+    ) -> Result<(), Error> {
+        if let Some(blob_address) = self.auth_blob_address {
+            let auth_blob_address_in_confidential_memory = memory_protector.translate_address(&blob_address)?;
+            // Make sure that the address is 8-bytes aligned. Once we ensure this, we can safely read 8 bytes because they must be within
+            // the page boundary. These 8 bytes should contain the `magic` (first 4 bytes) and `size` (next 4 bytes).
+            assure!(auth_blob_address_in_confidential_memory.is_aligned_to(8), Error::AuthBlobNotAlignedTo64Bits())?;
+            // Below use of unsafe is ok because (1) the security monitor owns the memory region containing the data of the not-yet-created
+            // confidential VM's and (2) there is only one physical hart executing this code.
+            let magic_and_size: usize = unsafe { auth_blob_address_in_confidential_memory.read_volatile() };
+            let auth_blob_total_size: usize = u32::from_be((magic_and_size >> 32) as u32) as usize;
+            // To work with the authentication blob, we must have it as a continous chunk of memory. We accept only authentication blobs
+            // that fit within 2MiB
+            assure!(auth_blob_total_size.div_ceil(PageSize::Size2MiB.in_bytes()) == 1, Error::AuthBlobInvalidSize())?;
+            let large_page = Self::relocate(memory_protector, &blob_address, auth_blob_total_size)?;
+
+            // TODO: verify authentication blob signature
+            // TODO: compare measurements to the one signed in the authentication blob
+
+            // Clean up, deallocate pages
+            PageAllocator::release_pages(alloc::vec![large_page.deallocate()]);
+        }
+        Ok(())
+    }
+
+    /// Copies a buffer into a single large page. This buffer is continuous across guest physical pages with G-stage address translation
+    /// enabled but might not be continuous across the real physical pages. Returns error if (1) the buffer to copy is larger than 2 MiB
+    /// page, or (2) the base address is not aligned to 8-bytes. The caller is responsible for deallocating the page.
+    fn relocate(
+        memory_protector: &ConfidentialVmMemoryProtector, base_address: &ConfidentialVmPhysicalAddress, number_of_bytes_to_copy: usize,
+    ) -> Result<Page<Allocated>, Error> {
+        assure!((base_address.usize() as *const u8).is_aligned_to(core::mem::size_of::<usize>()), Error::AddressNotProperlyAligned())?;
+        let mut large_page = PageAllocator::acquire_continous_pages(1, PageSize::Size2MiB)?.remove(0).zeroize();
+        // Let's copy a blob from confidential VM's pages into the newly allocated huge page. We will copy in chunks of 8-bytes (usize).
+        let mut copied_bytes = 0;
+        while copied_bytes < number_of_bytes_to_copy {
+            let confidential_vm_physical_address = base_address.add(copied_bytes);
+            let confidential_memory_address = memory_protector.translate_address(&confidential_vm_physical_address)?;
+            let value: usize = unsafe { confidential_memory_address.read_volatile() };
+            large_page.write(copied_bytes, value)?;
+            copied_bytes += core::mem::size_of::<usize>();
+        }
+        Ok(large_page)
     }
 }


### PR DESCRIPTION
This PR adds missing functionality to relocate FDT during the promotion of VM into a confidential VM. It also brings initial skeleton implementation for the local attestation.