### PR TITLE
Simplify page table representation

### DIFF
--- a/security-monitor/src/core/memory_protector/confidential_vm_memory_protector.rs
+++ b/security-monitor/src/core/memory_protector/confidential_vm_memory_protector.rs
@@ -4,7 +4,7 @@
 use crate::core::architecture::{HartArchitecturalState, Hgatp};
 use crate::core::control_data::ConfidentialVmId;
 use crate::core::memory_layout::{ConfidentialMemoryAddress, ConfidentialVmPhysicalAddress, NonConfidentialMemoryAddress};
-use crate::core::memory_protector::mmu::RootPageTable;
+use crate::core::memory_protector::mmu::PageTable;
 use crate::core::memory_protector::{mmu, pmp, PageSize};
 use crate::error::Error;
 
@@ -12,7 +12,7 @@ use crate::error::Error;
 /// it protects accesses to the memory which the confidential VM does not own.
 pub struct ConfidentialVmMemoryProtector {
     // Stores the page table configuration of the confidential VM.
-    root_page_table: RootPageTable,
+    root_page_table: PageTable,
     // Stores the value of the hypervisor G-stage address translation protocol register.
     hgatp: usize,
 }
@@ -33,7 +33,7 @@ impl ConfidentialVmMemoryProtector {
 
     pub fn set_confidential_vm_id(&mut self, id: ConfidentialVmId) {
         assert!(self.hgatp == 0);
-        let hgatp = Hgatp::new(self.root_page_table.address(), self.root_page_table.paging_system().hgatp_mode(), id.usize());
+        let hgatp = Hgatp::new(self.root_page_table.address(), self.root_page_table.hgatp_mode(), id.usize());
         self.hgatp = hgatp.bits();
     }
 
@@ -80,7 +80,7 @@ impl ConfidentialVmMemoryProtector {
         super::tlb::clear_hart_tlbs();
     }
 
-    pub fn into_root_page_table(self) -> RootPageTable {
+    pub fn into_root_page_table(self) -> PageTable {
         self.root_page_table
     }
 }

--- a/security-monitor/src/core/memory_protector/mmu/mod.rs
+++ b/security-monitor/src/core/memory_protector/mmu/mod.rs
@@ -6,7 +6,7 @@ use crate::core::memory_layout::NonConfidentialMemoryAddress;
 use crate::error::Error;
 
 pub use page_size::PageSize;
-pub use page_table::RootPageTable;
+pub use page_table::PageTable;
 pub use paging_system::PagingSystem;
 pub use shared_page::SharedPage;
 
@@ -17,11 +17,11 @@ mod page_table_level;
 mod paging_system;
 mod shared_page;
 
-pub fn copy_mmu_configuration_from_non_confidential_memory(hgatp: Hgatp) -> Result<RootPageTable, Error> {
+pub fn copy_mmu_configuration_from_non_confidential_memory(hgatp: Hgatp) -> Result<PageTable, Error> {
     let paging_mode = hgatp.mode().ok_or_else(|| Error::UnsupportedPagingMode())?;
     let paging_system = PagingSystem::from(&paging_mode).ok_or_else(|| Error::UnsupportedPagingMode())?;
     let root_page_address = NonConfidentialMemoryAddress::new(hgatp.address() as *mut usize)?;
-    Ok(RootPageTable::copy_from_non_confidential_memory(root_page_address, paging_system)?)
+    Ok(PageTable::copy_from_non_confidential_memory(root_page_address, paging_system, paging_system.levels())?)
 }
 
 pub fn enable_address_translation(hgatp: usize) {

--- a/security-monitor/src/core/memory_protector/mmu/page_size.rs
+++ b/security-monitor/src/core/memory_protector/mmu/page_size.rs
@@ -18,10 +18,6 @@ pub enum PageSize {
 }
 
 impl PageSize {
-    // Usually there are 512 pages of size x that can fit in a single page of size y, where y is next page size larger than x (e.g., 2MiB
-    // and 4KiB).
-    pub const TYPICAL_NUMBER_OF_PAGES_INSIDE_LARGER_PAGE: usize = 512;
-
     pub fn in_bytes(&self) -> usize {
         match self {
             PageSize::Size128TiB => 8 * 512 * 512 * 512 * 512 * 256,

--- a/security-monitor/src/core/memory_protector/mmu/page_table.rs
+++ b/security-monitor/src/core/memory_protector/mmu/page_table.rs
@@ -16,8 +16,8 @@ use alloc::vec::Vec;
 
 /// Represents the architectural 2nd level page table that configures guest physical to real address translation. The security monitor fully controls these mappings for confidential VMs.
 ///
-/// We represent page table in two ways, logical and serialized, and make sure both are always equivalent, i.e., changes to the logical
-/// representation triggers changes to the serialized representation, so these two are always synced. Since the security monitor is
+/// We represent page tables in two ways, logical and serialized, and make sure both are always equivalent, i.e., changes to the logical
+/// representation trigger changes to the serialized representation, so these two are always synced. Since the security monitor is
 /// uninterruptible and access to page table configuration is synchronized for different security monitor threads, the changes are
 /// considered atomic.
 ///

--- a/security-monitor/src/core/memory_protector/mmu/page_table.rs
+++ b/security-monitor/src/core/memory_protector/mmu/page_table.rs
@@ -14,7 +14,7 @@ use crate::error::Error;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-/// Represents the architectural 2nd level page table that configures guest physical to real address translation. The security monitors fully controls these mappings for confidential VMs.
+/// Represents the architectural 2nd level page table that configures guest physical to real address translation. The security monitor fully controls these mappings for confidential VMs.
 ///
 /// We represent page table in two ways, logical and serialized, and make sure both are always equivalent, i.e., changes to the logical
 /// representation triggers changes to the serialized representation, so these two are always synced. Since the security monitor is

--- a/security-monitor/src/core/memory_protector/mmu/page_table.rs
+++ b/security-monitor/src/core/memory_protector/mmu/page_table.rs
@@ -14,8 +14,7 @@ use crate::error::Error;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-/// Represents an architectural 2nd level page table configuring guest physical to real address translation. Security monitors fully
-/// controls these mappings for confidential VMs.
+/// Represents the architectural 2nd level page table that configures guest physical to real address translation. The security monitors fully controls these mappings for confidential VMs.
 ///
 /// We represent page table in two ways, logical and serialized, and make sure both are always equivalent, i.e., changes to the logical
 /// representation triggers changes to the serialized representation, so these two are always synced. Since the security monitor is
@@ -94,7 +93,8 @@ impl PageTable {
     /// structure.
     pub fn empty(paging_system: PagingSystem, level: PageTableLevel) -> Result<Self, Error> {
         let serialized_representation = PageAllocator::acquire_page(paging_system.memory_page_size(level))?.zeroize();
-        let logical_representation = Vec::with_capacity(serialized_representation.size().in_bytes() / paging_system.entry_size());
+        let number_of_entries = serialized_representation.size().in_bytes() / paging_system.entry_size();
+        let logical_representation = Vec::with_capacity(number_of_entries);
         Ok(Self { level, paging_system, serialized_representation, logical_representation })
     }
 


### PR DESCRIPTION
This PR simplifies the page table representation. Specifically, it removes the RootPageTable type that is no longer needed after we migrated to the new representation of the page table memory.

Additionally, we can simplify the `PageTable::deallocate()` because our new implementation of the page allocator is no longer sensitive to the page deallocation order.