### PR TITLE
Instructions to run ACE on P550

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,16 @@
 
 ACE-RISCV is an open-source project, whose goal is to deliver a confidential computing framework with a formally proven security monitor. It is based on the [canonical architecture](https://dl.acm.org/doi/pdf/10.1145/3623652.3623668) and targets RISC-V with the goal of being portable to other architectures. The formal verification efforts focus on the [security monitor implementation](security-monitor/). We invite collaborators to work with us to push the boundaries of provable confidential computing technology.
 
+**Formal verification:**
 This project implements the RISC-V CoVE spec's deployment model 3 referenced in [Appendix D](https://github.com/riscv-non-isa/riscv-ap-tee/blob/main/). The formal specification is embedded in the security monitor's source code and the proofs are in the [verification/](verification/) folder. Please read our [paper](https://dl.acm.org/doi/pdf/10.1145/3623652.3623668) to learn about the approach and goals.
+
+**Post-Quantum Cryptography (PQC) and Attestation**: ACE supports local attestation, a mechanism to authenticate confidential VMs intended for embedded systems with limited or no network connectivity. We already support PQC, specifically we use ML-KEM, SHA-384, and AES-GCM-256 cryptography.
 
 ## Hardware requirements
 We are currently building on RISC-V 64-bit with integer (I), atomic (A) and hypervisor extentions (H), physical memory protection (PMP), memory management unit (MMU), IOPMP, core-local interrupt controller (CLINT), and supervisor timecmp extension (Sstc).
+
+**Real RISC-V hardware to run ACE:**
+* SiFive P550 evaluation board, [see instructions](security-monitor/platform/p550).
 
 ## Quick Start
 Follow instructions to run one of the sample [confidential workloads](confidential-vms) under an [untrusted Linux KVM hypervisor](hypervisor/) in an emulated RISC-V environment.

--- a/security-monitor/platform/p550/README.md
+++ b/security-monitor/platform/p550/README.md
@@ -19,24 +19,24 @@ Let's build now the ACE security monitor. Make sure that we have access to the s
 ```
 YOCTO_RISCV_GNU_TOOLCHAIN_DIR=$YOCTO_DIR/build/tmp/sysroots-components/x86_64/gcc-cross-riscv64/usr/bin/riscv64-freedomusdk-linux/
 YOCTO_CROSS_COMPILE=riscv64-freedomusdk-linux-
-ls -lah $YOCTO_RISCV_GNU_TOOLCHAIN_DIR/$YOCTO_CROSS_COMPILE-gcc
+ls -lah $YOCTO_RISCV_GNU_TOOLCHAIN_DIR/${YOCTO_CROSS_COMPILE}gcc
 ```
 
 Let's download ACE sources dedicated for SiFive P550.
 ```
-ACE_SRC=/tmp/ace
+export ACE_SRC=/tmp/ace
+export ACE_DIR=$ACE_SRC/build/
 git clone --recurse-submodules -b sifive_p550 git@github.com:IBM/ACE-RISCV.git $ACE_SRC
 ```
 
 Build the version of the ACE security monitor dedicated for P550.
 ```
-cd $ACE_SRC
-RISCV_GNU_TOOLCHAIN_WORK_DIR=$YOCTO_RISCV_GNU_TOOLCHAIN_DIR CROSS_COMPILE=$YOCTO_CROSS_COMPILE make -j192 security_monitor
+RISCV_GNU_TOOLCHAIN_WORK_DIR=$YOCTO_RISCV_GNU_TOOLCHAIN_DIR CROSS_COMPILE=$YOCTO_CROSS_COMPILE make -j192 -C $ACE_SRC security_monitor
 ```
 
 Check presentence of the static library (`libace.a`) that contains the ACE security monitor.
 ```
-ls -lah $ACE_SRC/build/security-monitor/libace.a
+ls -lah $ACE_DIR/security-monitor/libace.a
 ```
 
 ### Build OpenSBI linked with the ACE security monitor
@@ -68,12 +68,12 @@ RISCV_GNU_TOOLCHAIN_WORK_DIR=$YOCTO_RISCV_GNU_TOOLCHAIN_DIR CROSS_COMPILE=$YOCTO
 
 Check that the host Linux kernel image was built:
 ```
-ls -lah $ACE_DIR/build/hypervisor/buildroot/build/linux-6.6.21/arch/riscv/boot/Image.gz
+ls -lah $ACE_DIR/hypervisor/buildroot/build/linux-6.6.21/arch/riscv/boot/Image.gz
 ```
 
 You can copy `Image.gz` to P550 with `scp` and then copy it to the /boot folder and reboot the system.
 ```
-scp $ACE_DIR/build/hypervisor/buildroot/build/linux-6.6.21/arch/riscv/boot/Image.gz login@ip_of_p550:/tmp
+scp $ACE_DIR/hypervisor/buildroot/build/linux-6.6.21/arch/riscv/boot/Image.gz login@ip_of_p550:/tmp
 # you must adjust below command so that you copy to the location of the boot drive:
 sudo cp /tmp/Image.gz /run/media/boot-mmcblk0p1/Image.gz
 ```
@@ -93,7 +93,7 @@ make -j192 confidential_vms
 
 Check that the VM image was built:
 ```
-ls -lah $ACE_DIR/build/confidential_vms/linux_vm/buildroot/images/*
+ls -lah $ACE_DIR/confidential_vms/linux_vm/buildroot/images/*
 # The following files should be present
 #   Image - contains guest Linux kernel
 #   rootfs.ext4 - root filesystem
@@ -102,7 +102,7 @@ ls -lah $ACE_DIR/build/confidential_vms/linux_vm/buildroot/images/*
 
 Now, use the `scp` tool to copy the VM image files to your P550 evaluation board.
 ```
-scp $ACE_DIR/build/confidential_vms/linux_vm/buildroot/images/* login@ip_of_p550:/tmp
+scp $ACE_DIR/confidential_vms/linux_vm/buildroot/images/* login@ip_of_p550:/tmp
 ```
 
 Now, run the test confidential VM on P550:

--- a/security-monitor/platform/p550/README.md
+++ b/security-monitor/platform/p550/README.md
@@ -20,9 +20,12 @@ At this point, we have built the original SiFive P550 firmware. We will need the
 ### Build ACE security monitor
 Let's build now the ACE security monitor. Make sure that we have access to the same compiler that yocto used to compile OpenSBI firmware.
 ```
-YOCTO_RISCV_GNU_TOOLCHAIN_DIR=$YOCTO_DIR/build/tmp/sysroots-components/x86_64/gcc-cross-riscv64/usr/bin/riscv64-freedomusdk-linux/
+YOCTO_RISCV_GNU_TOOLCHAIN_DIR=$YOCTO_DIR/build/tmp/work/riscv64-freedomusdk-linux/opensbi-sifive-hf-prem/1.4/recipe-sysroot-native/usr/bin/riscv64-freedomusdk-linux/
 YOCTO_CROSS_COMPILE=riscv64-freedomusdk-linux-
 ls -lah $YOCTO_RISCV_GNU_TOOLCHAIN_DIR/${YOCTO_CROSS_COMPILE}gcc
+
+# If you have problems with getting above compiler, you might try to force yocto to build just OpenSBI using `devtool` from poky:
+# $POKY_DIR/layers/build/scripts/devtool --basepath=$YOCTO_DIR/build build opensbi-sifive-hf-prem
 ```
 
 Let's download ACE sources dedicated for SiFive P550.

--- a/security-monitor/platform/p550/README.md
+++ b/security-monitor/platform/p550/README.md
@@ -1,9 +1,10 @@
 # Supported hardware
 
 ## SiFive P550 evaluation board
-This RISC-V processor is not compliant with RISC-V CoVE spec because it does not implement the Sstc extension. We have a version of ACE that implements missing features and thus runs on P550.
+This RISC-V processor is not compliant with RISC-V CoVE spec because (1) it implement a pre-reatified version of the H extensions, (2) it does not implement the Sstc extension. However, we have a version of ACE that emulates these missing hardware features. Thus, we can run experimentally ACE on SiFive P550.
 
-Build first the clean version of SiFive firmware. We use the version `2024.09.00-HFP550` because this is the version that was available when we were working with P550.
+### Build SiFive p550 firmware
+We start by building SiFive firmware without any modifications. We use the version `2024.09.00-HFP550` because this is the version that was available when we were working with the P550 evaluation board.
 ```
 export YOCTO_DIR=/tmp/yocto
 mkdir -p $YOCTO_DIR && cd $YOCTO_DIR
@@ -11,28 +12,40 @@ git clone https://github.com/sifive/freedom-u-sdk.git -b 2024.09.00-HFP550
 BB_NUMBER_THREADS="192" PARALLEL_MAKE="-j 192" kas build $YOCTO_DIR/freedom-u-sdk/scripts/kas/hifive-premier-p550.yml
 ```
 
-At this point, we have built the original SiFive P550 firmware. Let's build now the ACE security monitor. Make sure that we have access to the same compiler that yocto used to compile OpenSBI firmware.
+At this point, we have built the original SiFive P550 firmware. We will need the same compiler that built SiFive firmware to build ACE components.
+
+### Build ACE security monitor
+Let's build now the ACE security monitor. Make sure that we have access to the same compiler that yocto used to compile OpenSBI firmware.
 ```
-export RISCV_GNU_TOOLCHAIN_WORK_DIR=$YOCTO_DIR/build/tmp/sysroots-components/x86_64/gcc-cross-riscv64/usr/bin/riscv64-freedomusdk-linux/
-ls -lah $RISCV_GNU_TOOLCHAIN_WORK_DIR/riscv64-freedomusdk-linux-gcc
+YOCTO_RISCV_GNU_TOOLCHAIN_DIR=$YOCTO_DIR/build/tmp/sysroots-components/x86_64/gcc-cross-riscv64/usr/bin/riscv64-freedomusdk-linux/
+YOCTO_CROSS_COMPILE=riscv64-freedomusdk-linux-
+ls -lah $YOCTO_RISCV_GNU_TOOLCHAIN_DIR/$YOCTO_CROSS_COMPILE-gcc
 ```
 
-Let's download ACE sources and build the ACE security monitor for P550.
+Let's download ACE sources dedicated for SiFive P550.
 ```
 ACE_SRC=/tmp/ace
 git clone --recurse-submodules -b sifive_p550 git@github.com:IBM/ACE-RISCV.git $ACE_SRC
-cd $ACE_SRC
-make -j192 security_monitor
 ```
 
-Let's patch SiFive's firmware so that we build its version linked with the ACE security monitor.
+Build the version of the ACE security monitor dedicated for P550.
 ```
-cd meta-sifive
+cd $ACE_SRC
+RISCV_GNU_TOOLCHAIN_WORK_DIR=$YOCTO_RISCV_GNU_TOOLCHAIN_DIR CROSS_COMPILE=$YOCTO_CROSS_COMPILE make -j192 security_monitor
+```
+
+Check presentence of the static library (`libace.a`) that contains the ACE security monitor.
+```
+ls -lah $ACE_SRC/build/security-monitor/libace.a
+```
+
+### Build OpenSBI linked with the ACE security monitor
+Let's patch SiFive's firmware. We will build OpenSBI version that is linked with the ACE security monitor and QEMU patches with support to run confidential VMs.
+```
+cd $YOCTO_DIR/meta-sifive
 git apply $ACE_SRC/security-monitor/platform/p550/patches/meta-sifive/ace.patch
-cd ../
-cd openembedded-core
+cd $YOCTO_DIR/openembedded-core
 git apply /home/woz/ace/security-monitor/platform/p550/patches/openembedded-core/qemu_ace.patch
-cd ../
 ```
 
 Now its time to build the patched firmware again. Yocto will rebuilt only the components we patched, so the build process will be much faster than the initial build.
@@ -40,31 +53,63 @@ Now its time to build the patched firmware again. Yocto will rebuilt only the co
 BB_NUMBER_THREADS="192" PARALLEL_MAKE="-j 192" kas build $YOCTO_DIR/freedom-u-sdk/scripts/kas/hifive-premier-p550.yml
 ```
 
-Now you can flash the new version of firmware following the standard procedure described by SiFive on its website.
+Check that the firmware has been built.
 ```
-# Firmware including the ACE security monitor
-ls $YOCTO_DIR/build/tmp/deploy/images/hifive-premier-p550/bootloader_ddr5_secboot.bin
+ls -lah $YOCTO_DIR/build/tmp/deploy/images/hifive-premier-p550/bootloader_ddr5_secboot.bin
 ```
 
-I did not have time to prepare nice Linux kernel patches for yocto, so you should build the Linux kernel with CoVE patches from sources `https://github.com/wojciechozga/linux-cove/tree/woz/linux_6.6.21_ace_p550` or using buildroot:
+Now you can flash the new version of firmware following the standard procedure described by SiFive on its website.
+
+### Build host Linux kernel
 ```
 cd $ACE_SRC
-make -j192 hypervisor
-# the Linux kernel Image should be here
-ls $ACE_DIR/build/hypervisor/buildroot/build/linux-6.6.21/arch/riscv/boot/Image.gz
+RISCV_GNU_TOOLCHAIN_WORK_DIR=$YOCTO_RISCV_GNU_TOOLCHAIN_DIR CROSS_COMPILE=$YOCTO_CROSS_COMPILE make -j192 hypervisor
 ```
 
-After all, you can copy `Image.gz` to P550 with `scp` and then copy it to the /boot folder and reboot the system. If everything went well, you should see that KVM printed the following line to dmesg
+Check that the host Linux kernel image was built:
 ```
-hifive-premier-p550:~$ dmesg | grep TSM
-[    1.126289] kvm [1]: TSM version 9 is loaded and ready to run
+ls -lah $ACE_DIR/build/hypervisor/buildroot/build/linux-6.6.21/arch/riscv/boot/Image.gz
 ```
 
-Now, you can run a confidential VM
+You can copy `Image.gz` to P550 with `scp` and then copy it to the /boot folder and reboot the system.
 ```
-KERNEL=/path_to_TVM_kernel
-DRIVE=/path_to_TVM_filesystem
-TAP=/path_to_TVM_TAP
+scp $ACE_DIR/build/hypervisor/buildroot/build/linux-6.6.21/arch/riscv/boot/Image.gz login@ip_of_p550:/tmp
+# you must adjust below command so that you copy to the location of the boot drive:
+sudo cp /tmp/Image.gz /run/media/boot-mmcblk0p1/Image.gz
+```
+
+Once you start your evaluation board with firmware containing ACE and host Linux kernel contianing CoVE patches, you should see that KVM printed the following line to dmesg:
+```
+dmesg | grep TSM
+# expected output:
+# [    1.126289] kvm [1]: TSM version 9 is loaded and ready to run
+```
+
+### Build a test confidential VM
+```
+cd $ACE_SRC
+make -j192 confidential_vms
+```
+
+Check that the VM image was built:
+```
+ls -lah $ACE_DIR/build/confidential_vms/linux_vm/buildroot/images/*
+# The following files should be present
+#   Image - contains guest Linux kernel
+#   rootfs.ext4 - root filesystem
+#   cove_tap_qemu - TVM attestation payload (for local attestation)
+```
+
+Now, use the `scp` tool to copy the VM image files to your P550 evaluation board.
+```
+scp $ACE_DIR/build/confidential_vms/linux_vm/buildroot/images/* login@ip_of_p550:/tmp
+```
+
+Now, run the test confidential VM on P550:
+```
+KERNEL=/tmp/Image
+DRIVE=/tmp/rootfs.ext4
+TAP=/tmp/cove_tap_qemu
 SMP=1
 MEMORY=1G
 HOST_PORT=10101
@@ -78,4 +123,11 @@ qemu-system-riscv64 --enable-kvm -nographic \
     -drive if=none,format=raw,file=${DRIVE},id=hd0 \
     -device virtio-net-pci,netdev=net0,iommu_platform=on,disable-legacy=on,disable-modern=off \
     -netdev user,id=net0,net=192.168.100.1/24,dhcpstart=192.168.100.128,hostfwd=tcp::${HOST_PORT}-:22
+```
+
+After a few seconds, you should see the login prompt to your confidential VM. Congratulations!
+```
+# credentials to test confidential VM
+login: root
+password: passwd
 ```

--- a/security-monitor/platform/p550/README.md
+++ b/security-monitor/platform/p550/README.md
@@ -1,10 +1,13 @@
 # Supported hardware
 
 ## SiFive P550 evaluation board
-This RISC-V processor is not compliant with RISC-V CoVE spec because (1) it implement a pre-reatified version of the H extensions, (2) it does not implement the Sstc extension. However, we have a version of ACE that emulates these missing hardware features. Thus, we can run experimentally ACE on SiFive P550.
+This RISC-V processor is not compliant with the RISC-V CoVE specification because (1) it implements a pre-ratified version of the H extension, and (2) it does not support the Sstc extension. However, we have developed a version of ACE that emulates these missing hardware features. As a result, we are able to experimentally run ACE on the SiFive P550.
+
+Below process is not well integrated with YOCTO and requires manual execution of certain steps. We welcome pull requests to provide YOCTO integration.
 
 ### Build SiFive p550 firmware
-We start by building SiFive firmware without any modifications. We use the version `2024.09.00-HFP550` because this is the version that was available when we were working with the P550 evaluation board.
+We begin by building the SiFive firmware without any modifications. We use version `2024.09.00-HFP550`, as it was the version available at the time we worked with the P550 evaluation board.
+
 ```
 export YOCTO_DIR=/tmp/yocto
 mkdir -p $YOCTO_DIR && cd $YOCTO_DIR

--- a/security-monitor/platform/p550/README.md
+++ b/security-monitor/platform/p550/README.md
@@ -1,0 +1,81 @@
+# Supported hardware
+
+## SiFive P550 evaluation board
+This RISC-V processor is not compliant with RISC-V CoVE spec because it does not implement the Sstc extension. We have a version of ACE that implements missing features and thus runs on P550.
+
+Build first the clean version of SiFive firmware. We use the version `2024.09.00-HFP550` because this is the version that was available when we were working with P550.
+```
+export YOCTO_DIR=/tmp/yocto
+mkdir -p $YOCTO_DIR && cd $YOCTO_DIR
+git clone https://github.com/sifive/freedom-u-sdk.git -b 2024.09.00-HFP550
+BB_NUMBER_THREADS="192" PARALLEL_MAKE="-j 192" kas build $YOCTO_DIR/freedom-u-sdk/scripts/kas/hifive-premier-p550.yml
+```
+
+At this point, we have built the original SiFive P550 firmware. Let's build now the ACE security monitor. Make sure that we have access to the same compiler that yocto used to compile OpenSBI firmware.
+```
+export RISCV_GNU_TOOLCHAIN_WORK_DIR=$YOCTO_DIR/build/tmp/sysroots-components/x86_64/gcc-cross-riscv64/usr/bin/riscv64-freedomusdk-linux/
+ls -lah $RISCV_GNU_TOOLCHAIN_WORK_DIR/riscv64-freedomusdk-linux-gcc
+```
+
+Let's download ACE sources and build the ACE security monitor for P550.
+```
+ACE_SRC=/tmp/ace
+git clone --recurse-submodules -b sifive_p550 git@github.com:IBM/ACE-RISCV.git $ACE_SRC
+cd $ACE_SRC
+make -j192 security_monitor
+```
+
+Let's patch SiFive's firmware so that we build its version linked with the ACE security monitor.
+```
+cd meta-sifive
+git apply $ACE_SRC/security-monitor/platform/p550/patches/meta-sifive/ace.patch
+cd ../
+cd openembedded-core
+git apply /home/woz/ace/security-monitor/platform/p550/patches/openembedded-core/qemu_ace.patch
+cd ../
+```
+
+Now its time to build the patched firmware again. Yocto will rebuilt only the components we patched, so the build process will be much faster than the initial build.
+```
+BB_NUMBER_THREADS="192" PARALLEL_MAKE="-j 192" kas build $YOCTO_DIR/freedom-u-sdk/scripts/kas/hifive-premier-p550.yml
+```
+
+Now you can flash the new version of firmware following the standard procedure described by SiFive on its website.
+```
+# Firmware including the ACE security monitor
+ls $YOCTO_DIR/build/tmp/deploy/images/hifive-premier-p550/bootloader_ddr5_secboot.bin
+```
+
+I did not have time to prepare nice Linux kernel patches for yocto, so you should build the Linux kernel with CoVE patches from sources `https://github.com/wojciechozga/linux-cove/tree/woz/linux_6.6.21_ace_p550` or using buildroot:
+```
+cd $ACE_SRC
+make -j192 hypervisor
+# the Linux kernel Image should be here
+ls $ACE_DIR/build/hypervisor/buildroot/build/linux-6.6.21/arch/riscv/boot/Image.gz
+```
+
+After all, you can copy `Image.gz` to P550 with `scp` and then copy it to the /boot folder and reboot the system. If everything went well, you should see that KVM printed the following line to dmesg
+```
+hifive-premier-p550:~$ dmesg | grep TSM
+[    1.126289] kvm [1]: TSM version 9 is loaded and ready to run
+```
+
+Now, you can run a confidential VM
+```
+KERNEL=/path_to_TVM_kernel
+DRIVE=/path_to_TVM_filesystem
+TAP=/path_to_TVM_TAP
+SMP=1
+MEMORY=1G
+HOST_PORT=10101
+
+qemu-system-riscv64 --enable-kvm -nographic \
+    -machine virt,cove=true,cove-tap-filename=${TAP} -cpu rv64,sstc=false,f=true -smp ${SMP} -m ${MEMORY} \
+    -kernel ${KERNEL} \
+    -global virtio-mmio.force-legacy=false \
+    -append "ro root=/dev/vda swiotlb=mmnn,force" \
+    -device virtio-blk-pci,drive=hd0,iommu_platform=on,disable-legacy=on,disable-modern=off \
+    -drive if=none,format=raw,file=${DRIVE},id=hd0 \
+    -device virtio-net-pci,netdev=net0,iommu_platform=on,disable-legacy=on,disable-modern=off \
+    -netdev user,id=net0,net=192.168.100.1/24,dhcpstart=192.168.100.128,hostfwd=tcp::${HOST_PORT}-:22
+```

--- a/security-monitor/platform/p550/patches/meta-sifive/ace.patch
+++ b/security-monitor/platform/p550/patches/meta-sifive/ace.patch
@@ -1,0 +1,217 @@
+diff --git a/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0009-ace.patch b/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0009-ace.patch
+new file mode 100644
+index 0000000..77f2315
+--- /dev/null
++++ b/recipes-bsp/opensbi/opensbi-sifive-hf-prem/0009-ace.patch
+@@ -0,0 +1,149 @@
++
++
++
++
++diff --git a/lib/sbi/sbi_domain.c b/lib/sbi/sbi_domain.c
++index 06c60ae..3582e74 100644
++--- a/lib/sbi/sbi_domain.c
+++++ b/lib/sbi/sbi_domain.c
++@@ -796,16 +796,16 @@ int sbi_domain_init(struct sbi_scratch *scratch, u32 cold_hartid)
++ 	root.possible_harts = root_hmask;
++
++ 	/* Root domain firmware memory region */
++-	sbi_domain_memregion_init(scratch->fw_start, scratch->fw_rw_offset,
++-				  (SBI_DOMAIN_MEMREGION_M_READABLE |
+++	sbi_domain_memregion_init(scratch->fw_start, scratch->fw_size,
+++				  (SBI_DOMAIN_MEMREGION_M_READABLE | SBI_DOMAIN_MEMREGION_M_WRITABLE |
++ 				   SBI_DOMAIN_MEMREGION_M_EXECUTABLE),
++ 				  &root_memregs[root_memregs_count++],0);
++
++-	sbi_domain_memregion_init((scratch->fw_start + scratch->fw_rw_offset),
++-				  (scratch->fw_size - scratch->fw_rw_offset),
++-				  (SBI_DOMAIN_MEMREGION_M_READABLE |
++-				   SBI_DOMAIN_MEMREGION_M_WRITABLE),
++-				  &root_memregs[root_memregs_count++],0);
+++	// sbi_domain_memregion_init((scratch->fw_start + scratch->fw_rw_offset),
+++	// 			  (scratch->fw_size - scratch->fw_rw_offset),
+++	// 			  (SBI_DOMAIN_MEMREGION_M_READABLE |
+++	// 			   SBI_DOMAIN_MEMREGION_M_WRITABLE),
+++	// 			  &root_memregs[root_memregs_count++],0);
++
++ #ifdef CONFIG_PLATFORM_ESWIN
++ 	sbi_domain_memregion_init(0x1000000000UL, 0x3fffffUL, SBI_DOMAIN_MEMREGION_ENF_PERMISSIONS,
++diff --git a/lib/sbi/sbi_hart.c b/lib/sbi/sbi_hart.c
++index f621cdd..68b2b18 100644
++--- a/lib/sbi/sbi_hart.c
+++++ b/lib/sbi/sbi_hart.c
++@@ -435,7 +435,7 @@ static int sbi_hart_smepmp_configure(struct sbi_scratch *scratch,
++ 	pmp_disable(SBI_SMEPMP_RESV_ENTRY);
++
++ 	/* Program M-only regions when MML is not set. */
++-	pmp_idx = 0;
+++	pmp_idx = 2;
++ 	sbi_domain_for_each_memregion(dom, reg) {
++ 		/* Skip reserved entry */
++ 		if (pmp_idx == SBI_SMEPMP_RESV_ENTRY)
++@@ -461,7 +461,7 @@ static int sbi_hart_smepmp_configure(struct sbi_scratch *scratch,
++ 	csr_set(CSR_MSECCFG, MSECCFG_MML);
++
++ 	/* Program shared and SU-only regions */
++-	pmp_idx = 0;
+++	pmp_idx = 2;
++ 	sbi_domain_for_each_memregion(dom, reg) {
++ 		/* Skip reserved entry */
++ 		if (pmp_idx == SBI_SMEPMP_RESV_ENTRY)
++@@ -498,7 +498,7 @@ static int sbi_hart_oldpmp_configure(struct sbi_scratch *scratch,
++ {
++ 	struct sbi_domain_memregion *reg;
++ 	struct sbi_domain *dom = sbi_domain_thishart_ptr();
++-	unsigned int pmp_idx = 0;
+++	unsigned int pmp_idx = 2;
++ 	unsigned int pmp_flags;
++ 	unsigned long pmp_addr;
++
++diff --git a/lib/sbi/sbi_hsm.c b/lib/sbi/sbi_hsm.c
++index 3d60ceb..3870971 100644
++--- a/lib/sbi/sbi_hsm.c
+++++ b/lib/sbi/sbi_hsm.c
++@@ -26,6 +26,8 @@
++ #include <sbi/sbi_timer.h>
++ #include <sbi/sbi_console.h>
++
+++extern void ace_setup_this_hart();
+++
++ #define __sbi_hsm_hart_change_state(hdata, oldstate, newstate)		\
++ ({									\
++ 	long state = atomic_cmpxchg(&(hdata)->state, oldstate, newstate); \
++@@ -154,6 +156,8 @@ void __noreturn sbi_hsm_hart_start_finish(struct sbi_scratch *scratch,
++ 	next_mode = scratch->next_mode;
++ 	hsm_start_ticket_release(hdata);
++
+++	ace_setup_this_hart();
+++
++ 	sbi_hart_switch_mode(hartid, next_arg1, next_addr, next_mode, false);
++ }
++
++diff --git a/lib/sbi/sbi_init.c b/lib/sbi/sbi_init.c
++index 931ba7c..9c0454b 100644
++--- a/lib/sbi/sbi_init.c
+++++ b/lib/sbi/sbi_init.c
++@@ -80,6 +80,8 @@ static void sbi_boot_print_general(struct sbi_scratch *scratch)
++ 		return;
++
++ 	/* Platform details */
+++	sbi_printf("ACE: 2024.09.00-HFP550 release\n");
+++	sbi_printf("ACE: build version %d\n", 152);
++ 	sbi_printf("Platform Name             : %s\n",
++ 		   sbi_platform_name(plat));
++ 	sbi_platform_get_features_str(plat, str, sizeof(str));
++diff --git a/lib/utils/serial/uart8250.c b/lib/utils/serial/uart8250.c
++index 1fe053f..af114dd 100644
++--- a/lib/utils/serial/uart8250.c
+++++ b/lib/utils/serial/uart8250.c
++@@ -135,7 +135,12 @@ int uart8250_init(unsigned long base, u32 in_freq, u32 baudrate, u32 reg_shift,
++
++ 	sbi_console_set_device(&uart8250_console);
++
+++#ifdef CONFIG_PLATFORM_ESWIN
+++	/* For now, not adding memrange for UART as we are short of PMP regions */
+++	return 0;
+++#else
++ 	return sbi_domain_root_add_memrange(base, PAGE_SIZE, PAGE_SIZE,
++ 					    (SBI_DOMAIN_MEMREGION_MMIO |
++ 					    SBI_DOMAIN_MEMREGION_SHARED_SURW_MRW));
+++#endif
++ }
++diff --git a/platform/eswin/eic770x/objects.mk b/platform/eswin/eic770x/objects.mk
++index 8535107..7d6806d 100644
++--- a/platform/eswin/eic770x/objects.mk
+++++ b/platform/eswin/eic770x/objects.mk
++@@ -15,7 +15,7 @@ platform-objs-y += eic770x_uart.o
++ platform-cppflags-y =
++ platform-cflags-y =
++ platform-asflags-y =
++-platform-ldflags-y = -fno-stack-protector
+++platform-ldflags-y = -fno-stack-protector -L/opt/woz/ace_p550/security-monitor/ -lace
++
++ # Command for platform specific "make run"
++
++diff --git a/platform/eswin/eic770x/platform.c b/platform/eswin/eic770x/platform.c
++index e15df16..cbf581a 100644
++--- a/platform/eswin/eic770x/platform.c
+++++ b/platform/eswin/eic770x/platform.c
++@@ -30,6 +30,8 @@
++ #include <sbi/sbi_hart.h>
++ #include "eic770x_uart.h"
++
+++extern void init_security_monitor_asm(bool cold_boot, void *fdt);
+++
++ /* clang-format off */
++ #define EIC770X_HART_COUNT				4
++ #define DIE_REG_OFFSET					0
++@@ -225,6 +227,7 @@ static int eic770x_final_init(bool cold_boot)
++
++ 	fdt = sbi_scratch_thishart_arg1_ptr();
++ 	eic770x_modify_dt(fdt);
+++	init_security_monitor_asm(cold_boot, fdt);
++
++ 	return 0;
++ }
+diff --git a/recipes-bsp/opensbi/opensbi-sifive-hf-prem_1.4.bb b/recipes-bsp/opensbi/opensbi-sifive-hf-prem_1.4.bb
+index 4a7bf4b..8740670 100644
+--- a/recipes-bsp/opensbi/opensbi-sifive-hf-prem_1.4.bb
++++ b/recipes-bsp/opensbi/opensbi-sifive-hf-prem_1.4.bb
+@@ -21,13 +21,15 @@ SRC_URI:append = " \
+ 	file://0005-lib-sbi-Configure-CSR-registers.patch \
+ 	file://0006-lib-sbi-eic770x-Add-PMP-for-TOR-region.patch \
+ 	file://0007-sbi-init-Modify-CSR-values.patch \
++	file://0009-ace.patch \
+ "
+ 
+ S = "${WORKDIR}/git"
+ 
+ TARGET_CC_ARCH += "${LDFLAGS}"
+ 
+-EXTRA_OEMAKE += "PLATFORM=${RISCV_SBI_PLAT} CHIPLET="BR2_CHIPLET_1" CHIPLET_DIE_AVAILABLE="BR2_CHIPLET_1_DIE0_AVAILABLE" MEM_MODE="BR2_MEMMODE_FLAT" PLATFORM_CLUSTER_X_CORE="BR2_CLUSTER_4_CORE" PLATFORM_RISCV_ISA=rv64imafdc_zicsr_zifencei I=${D}"
++
++EXTRA_OEMAKE += "PLATFORM=${RISCV_SBI_PLAT} CHIPLET="BR2_CHIPLET_1" CHIPLET_DIE_AVAILABLE="BR2_CHIPLET_1_DIE0_AVAILABLE" MEM_MODE="BR2_MEMMODE_FLAT" PLATFORM_CLUSTER_X_CORE="BR2_CLUSTER_4_CORE" PLATFORM_RISCV_ISA=rv64imafdc_zicsr_zifencei PLATFORM_RISCV_ABI=lp64d I=${D}"
+ # If RISCV_SBI_PAYLOAD is set then include it as a payload
+ EXTRA_OEMAKE:append = " ${@riscv_get_extra_oemake_image(d)}"
+ EXTRA_OEMAKE:append = " ${@riscv_get_extra_oemake_fdt(d)}"
+diff --git a/recipes-bsp/u-boot/files/0002-ace-p550.patch b/recipes-bsp/u-boot/files/0002-ace-p550.patch
+new file mode 100644
+index 0000000..407d46f
+--- /dev/null
++++ b/recipes-bsp/u-boot/files/0002-ace-p550.patch
+@@ -0,0 +1,13 @@
++diff --git a/arch/riscv/cpu/eic7700/dram.c b/arch/riscv/cpu/eic7700/dram.c
++index a3521ac1e4..0728819cc2 100644
++--- a/arch/riscv/cpu/eic7700/dram.c
+++++ b/arch/riscv/cpu/eic7700/dram.c
++@@ -16,7 +16,7 @@ DECLARE_GLOBAL_DATA_PTR;
++ DECLARE_GLOBAL_DATA_PTR;
++
++ /* 32 GB */
++-#define DDR_SIZE_MAX    	0x800000000
+++#define DDR_SIZE_MAX    	0x200000000
++
++ /* 128 MB offset */
++ #define RAM_BASE_OFFSET 	0x8000000
+diff --git a/recipes-bsp/u-boot/u-boot-sifive-hf-prem_2024.01.bb b/recipes-bsp/u-boot/u-boot-sifive-hf-prem_2024.01.bb
+index 1887c67..55a9357 100644
+--- a/recipes-bsp/u-boot/u-boot-sifive-hf-prem_2024.01.bb
++++ b/recipes-bsp/u-boot/u-boot-sifive-hf-prem_2024.01.bb
+@@ -7,10 +7,16 @@ DEPENDS += "bc-native dtc-native"
+ 
+ SRCREV = "419a5fb2a92d338e813771acb0b50fefd9a1fea0"
+ SRC_URI = "git://github.com/eswincomputing/u-boot.git;protocol=https;branch=u-boot-2024.01-EIC7X \
+-           file://0001-riscv-hifive_premier_p550-defined-boot-media-sequenc.patch"
++           file://0001-riscv-hifive_premier_p550-defined-boot-media-sequenc.patch \
++           file://0002-ace-p550.patch \
++           "
+ 
+ do_deploy:append () {
+ 	install -m 755 ${B}/u-boot.dtb ${DEPLOYDIR}
++    cp ${DEPLOYDIR}/u-boot.dtb ${DEPLOYDIR}/u-boot_original.dtb
++    fdtput -c ${DEPLOYDIR}/u-boot.dtb /reserved-memory/ace-conf-mem
++    fdtput -t x ${DEPLOYDIR}/u-boot.dtb /reserved-memory/ace-conf-mem reg 0x2 0x80000000 0x2 0x0
++    fdtput -t s ${DEPLOYDIR}/u-boot.dtb /reserved-memory/ace-conf-mem no-map
+ }
+ 
+ COMPATIBLE_MACHINE = "hifive-premier-p550"

--- a/security-monitor/platform/p550/patches/openembedded-core/qemu_ace.patch
+++ b/security-monitor/platform/p550/patches/openembedded-core/qemu_ace.patch
@@ -1,0 +1,344 @@
+diff --git a/meta/recipes-devtools/qemu/qemu.inc b/meta/recipes-devtools/qemu/qemu.inc
+index 4501f84c2b..650c9ef430 100644
+--- a/meta/recipes-devtools/qemu/qemu.inc
++++ b/meta/recipes-devtools/qemu/qemu.inc
+@@ -39,6 +39,7 @@ SRC_URI = "https://download.qemu.org/${BPN}-${PV}.tar.xz \
+            file://0003-linux-user-Add-strace-for-shmat.patch \
+            file://0004-linux-user-Rewrite-target_shmat.patch \
+            file://0005-tests-tcg-Check-that-shmat-does-not-break-proc-self-.patch \
++           file://0013-ace_cove.patch \
+            file://CVE-2023-6683.patch \
+            file://qemu-guest-agent.init \
+            file://qemu-guest-agent.udev \
+diff --git a/meta/recipes-devtools/qemu/qemu/0013-ace_cove.patch b/meta/recipes-devtools/qemu/qemu/0013-ace_cove.patch
+new file mode 100644
+index 0000000000..6429e63347
+--- /dev/null
++++ b/meta/recipes-devtools/qemu/qemu/0013-ace_cove.patch
+@@ -0,0 +1,326 @@
++CVE: CVE-2022-1050
++Upstream-Status: Submitted [https://lore.kernel.org/qemu-devel/20220403095234.2210-1-yuval.shaia.ml@gmail.com/]
++Signed-off-by: Ross Burton <ross.burton@arm.com>
++
++From dbdef95c272e8f3ec037c3db4197c66002e30995 Mon Sep 17 00:00:00 2001
++From: Yuval Shaia <yuval.shaia.ml@gmail.com>
++Date: Sun, 3 Apr 2022 12:52:34 +0300
++Subject: [PATCH] hw/pvrdma: Protect against buggy or malicious guest driver
++
++Guest driver might execute HW commands when shared buffers are not yet
++allocated.
++This could happen on purpose (malicious guest) or because of some other
++guest/host address mapping error.
++We need to protect againts such case.
++
++Fixes: CVE-2022-1050
++
++Reported-by: Raven <wxhusst@gmail.com>
++Signed-off-by: Yuval Shaia <yuval.shaia.ml@gmail.com>
++---
++ hw/rdma/vmw/pvrdma_cmd.c | 6 ++++++
++ 1 file changed, 6 insertions(+)
++
++Index: qemu-8.0.0/hw/rdma/vmw/pvrdma_cmd.c
++===================================================================
++diff --git a/accel/kvm/kvm-all.c b/accel/kvm/kvm-all.c
++index e39a810a4e..5a2fc4c4cd 100644
++--- a/accel/kvm/kvm-all.c
+++++ b/accel/kvm/kvm-all.c
++@@ -2407,6 +2407,13 @@ static int kvm_init(MachineState *ms)
++         type = kvm_arch_get_default_type(ms);
++     }
++
+++    if (object_property_find(OBJECT(current_machine), "cove")) {
+++        if (object_property_get_bool(OBJECT(current_machine), "cove", &error_abort)) {
+++            type = 1UL << 10;
+++            warn_report("Creating CoVE TVM");
+++        }
+++    }
+++
++     if (type < 0) {
++         ret = -EINVAL;
++         goto err;
++diff --git a/hw/riscv/boot.c b/hw/riscv/boot.c
++index 0ffca05189..3902fe8871 100644
++--- a/hw/riscv/boot.c
+++++ b/hw/riscv/boot.c
++@@ -17,6 +17,8 @@
++  * this program.  If not, see <http://www.gnu.org/licenses/>.
++  */
++
+++#include <linux/kvm.h>
+++
++ #include "qemu/osdep.h"
++ #include "qemu/datadir.h"
++ #include "qemu/units.h"
++@@ -34,6 +36,24 @@
++
++ #include <libfdt.h>
++
+++enum KVM_RISCV_COVE_REGION {
+++	KVM_RISCV_COVE_REGION_FIRMWARE = 0,
+++	KVM_RISCV_COVE_REGION_KERNEL,
+++	KVM_RISCV_COVE_REGION_FDT,
+++	KVM_RISCV_COVE_REGION_INITRD,
+++	KVM_RISCV_COVE_REGION_COVE_TAP,
+++};
+++
+++struct kvm_riscv_cove_measure_region {
+++	unsigned long user_addr;
+++	unsigned long gpa;
+++	unsigned long size;
+++	enum KVM_RISCV_COVE_REGION type;
+++};
+++
+++struct kvm_riscv_cove_vm_finalize {
+++};
+++
++ bool riscv_is_32bit(RISCVHartArrayState *harts)
++ {
++     return harts->harts[0].env.misa_mxl_max == MXL_RV32;
++@@ -166,6 +186,7 @@ target_ulong riscv_load_firmware(const char *firmware_filename,
++                                            current_machine->ram_size, NULL);
++
++     if (firmware_size > 0) {
+++
++         return firmware_load_addr + firmware_size;
++     }
++
++@@ -205,6 +226,18 @@ static void riscv_load_initrd(MachineState *machine, uint64_t kernel_entry)
++         }
++     }
++
+++    #if defined(CONFIG_KVM)
+++    struct kvm_riscv_cove_measure_region mr = {
+++        .user_addr = 0,
+++        .gpa = start,
+++        .size = size,
+++        .type = KVM_RISCV_COVE_REGION_INITRD,
+++    };
+++    warn_report("Register initrd region %lx %ld", start, size);
+++    KVMState *s = KVM_STATE(machine->accelerator);
+++    kvm_vm_ioctl(s, KVM_RISCV_COVE_MEASURE_REGION, &mr);
+++    #endif
+++
++     /* Some RISC-V machines (e.g. opentitan) don't have a fdt. */
++     if (fdt) {
++         end = start + size;
++@@ -222,6 +255,7 @@ target_ulong riscv_load_kernel(MachineState *machine,
++     const char *kernel_filename = machine->kernel_filename;
++     uint64_t kernel_load_base, kernel_entry;
++     void *fdt = machine->fdt;
+++    ssize_t kernel_size;
++
++     g_assert(kernel_filename != NULL);
++
++@@ -232,20 +266,23 @@ target_ulong riscv_load_kernel(MachineState *machine,
++      * the (expected) load address load address. This allows kernels to have
++      * separate SBI and ELF entry points (used by FreeBSD, for example).
++      */
++-    if (load_elf_ram_sym(kernel_filename, NULL, NULL, NULL,
+++    kernel_size = load_elf_ram_sym(kernel_filename, NULL, NULL, NULL,
++                          NULL, &kernel_load_base, NULL, NULL, 0,
++-                         EM_RISCV, 1, 0, NULL, true, sym_cb) > 0) {
+++                         EM_RISCV, 1, 0, NULL, true, sym_cb);
+++    if (kernel_size > 0) {
++         kernel_entry = kernel_load_base;
++         goto out;
++     }
++
++-    if (load_uimage_as(kernel_filename, &kernel_entry, NULL, NULL,
++-                       NULL, NULL, NULL) > 0) {
+++    kernel_size = load_uimage_as(kernel_filename, &kernel_entry, NULL, NULL,
+++                       NULL, NULL, NULL);
+++    if (kernel_size > 0) {
++         goto out;
++     }
++
++-    if (load_image_targphys_as(kernel_filename, kernel_start_addr,
++-                               current_machine->ram_size, NULL) > 0) {
+++    kernel_size = load_image_targphys_as(kernel_filename, kernel_start_addr,
+++                               current_machine->ram_size, NULL);
+++    if (kernel_size > 0) {
++         kernel_entry = kernel_start_addr;
++         goto out;
++     }
++@@ -254,6 +291,35 @@ target_ulong riscv_load_kernel(MachineState *machine,
++     exit(1);
++
++ out:
+++    #if defined(CONFIG_KVM)
+++    struct kvm_riscv_cove_measure_region mr = {
+++        .user_addr = 0,
+++        .gpa = kernel_entry,
+++        .size = kernel_size,
+++        .type = KVM_RISCV_COVE_REGION_KERNEL,
+++    };
+++    warn_report("Register kernel region %lx %ld", kernel_entry, kernel_size);
+++    KVMState *s = KVM_STATE(machine->accelerator);
+++    kvm_vm_ioctl(s, KVM_RISCV_COVE_MEASURE_REGION, &mr);
+++
+++    if (object_property_find(OBJECT(current_machine), "cove-tap-filename")) {
+++        const char * tap_filename = object_property_get_str(OBJECT(current_machine), "cove-tap-filename", NULL);
+++        hwaddr tap_addr = (kernel_entry+kernel_size);
+++        tap_addr = ((4096-1) & tap_addr) ? ((tap_addr+4096) & ~(4096-1)) : tap_addr;
+++        error_report("Loading CoVE TAP %s %lx", tap_filename, tap_addr);
+++        if (load_image_targphys(tap_filename, tap_addr, 4096) <= 0) {
+++            error_report("Loading CoVE TAP failed");
+++        }
+++        struct kvm_riscv_cove_measure_region mr = {
+++            .user_addr = 0,
+++            .gpa = tap_addr,
+++            .size = 4096,
+++            .type = KVM_RISCV_COVE_REGION_COVE_TAP,
+++        };
+++        kvm_vm_ioctl(KVM_STATE(machine->accelerator), KVM_RISCV_COVE_MEASURE_REGION, &mr);
+++    }
+++    #endif
+++
++     /*
++      * For 32 bit CPUs 'kernel_entry' can be sign-extended by
++      * load_elf_ram_sym().
++diff --git a/hw/riscv/virt.c b/hw/riscv/virt.c
++index d2eac24156..eb5318efcd 100644
++--- a/hw/riscv/virt.c
+++++ b/hw/riscv/virt.c
++@@ -18,6 +18,8 @@
++  * this program.  If not, see <http://www.gnu.org/licenses/>.
++  */
++
+++
+++
++ #include "qemu/osdep.h"
++ #include "qemu/units.h"
++ #include "qemu/error-report.h"
++@@ -54,6 +56,27 @@
++ #include "hw/acpi/aml-build.h"
++ #include "qapi/qapi-visit-common.h"
++
+++#include <linux/kvm.h>
+++#include <libfdt.h>
+++
+++enum KVM_RISCV_COVE_REGION {
+++	KVM_RISCV_COVE_REGION_FIRMWARE = 0,
+++	KVM_RISCV_COVE_REGION_KERNEL,
+++	KVM_RISCV_COVE_REGION_FDT,
+++	KVM_RISCV_COVE_REGION_INITRD,
+++	KVM_RISCV_COVE_REGION_COVE_TAP,
+++};
+++
+++struct kvm_riscv_cove_measure_region {
+++	unsigned long user_addr;
+++	unsigned long gpa;
+++	unsigned long size;
+++	enum KVM_RISCV_COVE_REGION type;
+++};
+++
+++struct kvm_riscv_cove_vm_finalize {
+++};
+++
++ /*
++  * The virt machine physical address space used by some of the devices
++  * namely ACLINT, PLIC, APLIC, and IMSIC depend on number of Sockets,
++@@ -1322,6 +1345,17 @@ static void virt_machine_done(Notifier *notifier, void *data)
++                                            machine);
++     riscv_load_fdt(fdt_load_addr, machine->fdt);
++
+++    #if defined(CONFIG_KVM)
+++    uint32_t fdtsize = fdt_totalsize(machine->fdt);
+++    struct kvm_riscv_cove_measure_region mr = {
+++        .user_addr = 0,
+++        .gpa = fdt_load_addr,
+++        .size = fdtsize,
+++        .type = KVM_RISCV_COVE_REGION_FDT,
+++    };
+++    kvm_vm_ioctl(KVM_STATE(machine->accelerator), KVM_RISCV_COVE_MEASURE_REGION, &mr);
+++    #endif
+++
++     /* load the reset vector */
++     riscv_setup_rom_reset_vec(machine, &s->soc[0], start_addr,
++                               virt_memmap[VIRT_MROM].base,
++@@ -1340,6 +1374,12 @@ static void virt_machine_done(Notifier *notifier, void *data)
++     if (virt_is_acpi_enabled(s)) {
++         virt_acpi_setup(s);
++     }
+++
+++    #if defined(CONFIG_KVM)
+++    struct kvm_riscv_cove_vm_finalize finalize = {
+++    };
+++    kvm_vm_ioctl(KVM_STATE(machine->accelerator), KVM_RISCV_COVE_VM_FINALIZE, &finalize);
+++    #endif
++ }
++
++ static void virt_machine_init(MachineState *machine)
++@@ -1569,6 +1609,33 @@ static void virt_machine_instance_init(Object *obj)
++     s->acpi = ON_OFF_AUTO_AUTO;
++ }
++
+++static bool virt_get_cove(Object *obj, Error **errp)
+++{
+++    RISCVVirtState *s = RISCV_VIRT_MACHINE(obj);
+++
+++    return s->cove;
+++}
+++
+++static void virt_set_cove(Object *obj, bool value, Error **errp)
+++{
+++    RISCVVirtState *s = RISCV_VIRT_MACHINE(obj);
+++
+++    s->cove = value;
+++}
+++
+++static char *virt_get_cove_tap_filename(Object *obj, Error **errp)
+++{
+++    RISCVVirtState *s = RISCV_VIRT_MACHINE(obj);
+++    return g_strdup(s->cove_tap_filename);
+++}
+++
+++static void virt_set_cove_tap_filename(Object *obj, const char *val, Error **errp)
+++{
+++    RISCVVirtState *s = RISCV_VIRT_MACHINE(obj);
+++    g_free(s->cove_tap_filename);
+++    s->cove_tap_filename = g_strdup(val);
+++}
+++
++ static char *virt_get_aia_guests(Object *obj, Error **errp)
++ {
++     RISCVVirtState *s = RISCV_VIRT_MACHINE(obj);
++@@ -1743,6 +1810,10 @@ static void virt_machine_class_init(ObjectClass *oc, void *data)
++                               NULL, NULL);
++     object_class_property_set_description(oc, "acpi",
++                                           "Enable ACPI");
+++    object_class_property_add_bool(oc, "cove", virt_get_cove,
+++                                            virt_set_cove);
+++    object_class_property_add_str(oc, "cove-tap-filename", virt_get_cove_tap_filename,
+++                                          virt_set_cove_tap_filename);
++ }
++
++ static const TypeInfo virt_machine_typeinfo = {
++diff --git a/include/hw/riscv/virt.h b/include/hw/riscv/virt.h
++index e5c474b26e..c01e733b34 100644
++--- a/include/hw/riscv/virt.h
+++++ b/include/hw/riscv/virt.h
++@@ -60,6 +60,8 @@ struct RISCVVirtState {
++     char *oem_table_id;
++     OnOffAuto acpi;
++     const MemMapEntry *memmap;
+++    bool cove;
+++    char *cove_tap_filename;
++ };
++
++ enum {
++diff --git a/linux-headers/linux/kvm.h b/linux-headers/linux/kvm.h
++index 0d74ee999a..f6667cb13c 100644
++--- a/linux-headers/linux/kvm.h
+++++ b/linux-headers/linux/kvm.h
++@@ -1559,6 +1559,9 @@ struct kvm_s390_ucas_mapping {
++ /* Available with KVM_CAP_COUNTER_OFFSET */
++ #define KVM_ARM_SET_COUNTER_OFFSET _IOW(KVMIO,  0xb5, struct kvm_arm_counter_offset)
++
+++#define KVM_RISCV_COVE_MEASURE_REGION _IOR(KVMIO, 0xb6, struct kvm_riscv_cove_measure_region)
+++#define KVM_RISCV_COVE_VM_FINALIZE  _IOR(KVMIO, 0xb7, struct kvm_riscv_cove_vm_finalize)
+++
++ /* ioctl for vm fd */
++ #define KVM_CREATE_DEVICE	  _IOWR(KVMIO,  0xe0, struct kvm_create_device)
++


### PR DESCRIPTION
## Description of the changes
SiFive P550 is the evaluation board with the first RISC-V processor supporting the hypervisor extension. Since P550 is not compliant with the CoVE spec, we emulated missing hardware functionality in the security monitor, so that one can experiment with ACE on real RISC-V hardware. This PR provides instructions how to run ACE on P550.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Formal verification
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactorization (non-breaking change which improves code quality)