### PR TITLE
Improve interaction with OpenSBI

### DIFF
--- a/security-monitor/src/core/architecture/riscv/control_status_registers.rs
+++ b/security-monitor/src/core/architecture/riscv/control_status_registers.rs
@@ -301,6 +301,8 @@ pub struct ControlStatusRegister {
     pub mvendorid: ReadWriteRiscvCsr<CSR_MVENDORID>,
     pub marchid: ReadWriteRiscvCsr<CSR_MARCHID>,
     pub mimpid: ReadWriteRiscvCsr<CSR_MIMPID>,
+    pub mcause: ReadWriteRiscvCsr<CSR_MCAUSE>,
+    pub mstatus: ReadWriteRiscvCsr<CSR_MSTATUS>,
     pub mscratch: ReadWriteRiscvCsr<CSR_MSCRATCH>,
     pub hgatp: ReadWriteRiscvCsr<CSR_HGATP>,
     pub pmpcfg0: ReadWriteRiscvCsr<CSR_PMPCFG0>,
@@ -313,6 +315,8 @@ pub const CSR: &ControlStatusRegister = &ControlStatusRegister {
     mvendorid: ReadWriteRiscvCsr::new(),
     marchid: ReadWriteRiscvCsr::new(),
     mimpid: ReadWriteRiscvCsr::new(),
+    mcause: ReadWriteRiscvCsr::new(),
+    mstatus: ReadWriteRiscvCsr::new(),
     mscratch: ReadWriteRiscvCsr::new(),
     hgatp: ReadWriteRiscvCsr::new(),
     pmpcfg0: ReadWriteRiscvCsr::new(),
@@ -412,6 +416,17 @@ impl<const V: u16> ReadWriteRiscvCsr<V> {
                  rd = out(reg) r,
                  csr = const V,
                  rs1 = in(reg) bitmask);
+        }
+        r
+    }
+
+    pub fn swap(&self, value: usize) -> usize {
+        let r: usize;
+        unsafe {
+            asm!("csrrw {rd}, {csr}, {rs1}",
+                     rd = out(reg) r,
+                     csr = const V,
+                     rs1 = in(reg) value);
         }
         r
     }

--- a/security-monitor/src/core/initialization/mod.rs
+++ b/security-monitor/src/core/initialization/mod.rs
@@ -229,10 +229,8 @@ extern "C" fn ace_setup_this_hart() {
     // opensbi_mscratch in the internal hart state. OpenSBI stored in mscratch a pointer to the
     // `opensbi_mscratch` region of this hart before calling the security monitor's initialization
     // procedure. Thus, the swap will move the mscratch register value into the dump state of the hart
-    hart.swap_mscratch();
-    let hart_address = hart.hypervisor_hart().address();
-    hart.hypervisor_hart_mut().csrs_mut().mscratch.write(hart_address);
-    debug!("Hardware hart id={} has state area region at {:x}", hart_id, hart_address);
+    hart.set_ace_mscratch(hart.hypervisor_hart().address());
+    debug!("Hardware hart id={} has state area region at {:x}", hart_id, hart.hypervisor_hart().address());
 
     // Configure the memory isolation mechanism that can limit memory view of the hypervisor to the memory region
     // owned by the hypervisor. The setup method enables the memory isolation. It is safe to call it because


### PR DESCRIPTION
## Description of the changes
When running ACE on the SiFive P550 evaluation board, we recognized performance degradation due to inefficient trap handler implementation. Specifically, for interrupt in the system, we were making unnecessary memory store before handling the call to OpenSBI. This PR shortens the path, redirecting the execution to OpenSBI as soon as possible.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Formal verification
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactorization (non-breaking change which improves code quality or performance)