### PR TITLE
CI: upgrade to opam 2.3.0

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,10 +14,8 @@ jobs:
       with:
         persist-credentials: false
         submodules: 'true'
-    - name: Install opam dependencies
-      run: sudo apt update -y && sudo apt install -y pkg-config git rsync tar unzip m4 time curl ocaml build-essential bubblewrap gawk libgmp-dev python2.7 python3 python3-distutils libmpfr-dev
     - name: Install opam
-      run: curl "https://github.com/ocaml/opam/releases/download/2.1.5/opam-2.1.5-x86_64-linux" -Lo /usr/local/bin/opam && chmod +x /usr/local/bin/opam
+      run: sudo apt update && sudo apt install -y opam
     - name: Setup opam
       run: opam init -y
     - name: Setup opam switch


### PR DESCRIPTION
Directly get opam from Ubuntu.
This also drops the manual installs, including Python 2.7 which has been removed from Ubuntu.

