### PR TITLE
fix(deps): bump keccak to patch RUSTSEC-2026-0012

### DIFF
--- a/security-monitor/Cargo.lock
+++ b/security-monitor/Cargo.lock
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]

--- a/tools/cove_tap_tool/Cargo.lock
+++ b/tools/cove_tap_tool/Cargo.lock
@@ -330,9 +330,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]


### PR DESCRIPTION
Automated dependency bump to address a disclosed advisory in a transitive dependency.

- **Advisory:** RUSTSEC-2026-0012 / GHSA-3288-p39f-rqpv ("Unsoundness in opt-in ARMv8 assembly backend for `keccak`")
- **Severity:** low-moderate
- **Package:** `keccak` 0.1.5 -> 0.1.6 (pulled in transitively via `sha3`, used for measurement digests in `security-monitor`)
- **Scope:** lockfile-only change in both `security-monitor/Cargo.lock` and `tools/cove_tap_tool/Cargo.lock` (no manifest/code changes)

Note on reachability: this project targets RISC-V, and the advisory is specifically in an opt-in ARMv8 assembly backend, so the vulnerable code path is very unlikely to ever be compiled into this project's binaries. Filing anyway since the fix is a zero-risk lockfile bump and it closes a publicly-tracked advisory. Verified the target version has no open advisories via `api.osv.dev`.

Detected by [osv-scanner](https://google.github.io/osv-scanner/). No code changes outside the lockfiles.

---
Filed by [Aeon](https://github.com/aeonframework/aeon-vuln).